### PR TITLE
Force new resource when delegate_id or approve fields have changed

### DIFF
--- a/.changelog/115.txt
+++ b/.changelog/115.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/delegate_approval: Force new resource when `delegate_id` or `approve` fields change.
+```

--- a/internal/service/cd/delegate/delegate_approval.go
+++ b/internal/service/cd/delegate/delegate_approval.go
@@ -22,11 +22,13 @@ func ResourceDelegateApproval() *schema.Resource {
 				Description: "The id of the delegate.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"approve": {
 				Description: "Whether or not to approve the delegate.",
 				Type:        schema.TypeBool,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"status": {
 				Description: "The status of the delegate.",

--- a/internal/service/cd/delegate/delegate_approval.go
+++ b/internal/service/cd/delegate/delegate_approval.go
@@ -13,9 +13,8 @@ import (
 func ResourceDelegateApproval() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Resource for approving or rejecting delegates.",
-		CreateContext: resourceDelegateApprovalCreateOrUpdate,
+		CreateContext: resourceDelegateApprovalCreate,
 		ReadContext:   resourceDelegateApprovalRead,
-		UpdateContext: resourceDelegateApprovalCreateOrUpdate,
 		DeleteContext: resourceDelegateApprovalDelete,
 		Schema: map[string]*schema.Schema{
 			"delegate_id": {
@@ -73,13 +72,8 @@ func resourceDelegateApprovalRead(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceDelegateApprovalCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDelegateApprovalCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*internal.Session).CDClient
-
-	// Don't attempt to do anything if we've already done this once.
-	if !d.IsNewResource() {
-		return diag.Errorf("the delegate approval status has already been changed.")
-	}
 
 	id := d.Get("delegate_id").(string)
 	delegate, err := c.DelegateClient.GetDelegateById(id)


### PR DESCRIPTION
Fixes issue #104 