### PR TITLE
Fixed secret text test

### DIFF
--- a/internal/service/platform/secret/text_test.go
+++ b/internal/service/platform/secret/text_test.go
@@ -105,25 +105,11 @@ func TestAccResourceSecretText_reference(t *testing.T) {
 
 func testAccResourceSecret_text_inline(id string, name string) string {
 	return fmt.Sprintf(`
-	resource "harness_platform_organization" "org" {
-		identifier = "%[1]s"
-		name = "%[2]s"
-	}
-
-	resource "harness_platform_project" "project" {
-		identifier = "%[1]s"
-		name = "%[2]s"
-		org_id = harness_platform_organization.org.id
-		color = "#0063F7"
-	}
 		resource "harness_platform_secret_text" "test" {
 			identifier = "%[1]s"
 			name = "%[2]s"
 			description = "test"
 			tags = ["foo:bar"]
-			org_id = harness_platform_organization.org.id
-			project_id = harness_platform_project.project.id
-
 			secret_manager_identifier = "harnessSecretManager"
 			value_type = "Inline"
 			value = "secret"


### PR DESCRIPTION
Secret text was not working because of delay in creating default secret manager after project creation. We have added secret at account level in the test.