### PR TITLE
Update Issue Links in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 FEATURES:
 
-* **New Resource:** `platform_resource_group` ([#168](https://github.com/hashicorp/terraform-provider-harness/issues/168))
+* **New Resource:** `platform_resource_group` ([#168](https://github.com/harness/terraform-provider-harness/issues/168))
 
 BUG FIXES:
 
-* data-source/harness_platform_connector_kubernetes: Add delegate selectors. ([#169](https://github.com/hashicorp/terraform-provider-harness/issues/169))
-* resource/harness_platform_connector_kubernetes: Add delegate selectors. ([#169](https://github.com/hashicorp/terraform-provider-harness/issues/169))
-* resource/harness_platform_project: Fixed the vanishing color in project resource ([#166](https://github.com/hashicorp/terraform-provider-harness/issues/166))
+* data-source/harness_platform_connector_kubernetes: Add delegate selectors. ([#169](https://github.com/harness/terraform-provider-harness/issues/169))
+* resource/harness_platform_connector_kubernetes: Add delegate selectors. ([#169](https://github.com/harness/terraform-provider-harness/issues/169))
+* resource/harness_platform_project: Fixed the vanishing color in project resource ([#166](https://github.com/harness/terraform-provider-harness/issues/166))
 
 # 0.2.12
 
 FEATURES:
 
-* **New Resource:** `platform_roles` ([#161](https://github.com/hashicorp/terraform-provider-harness/issues/161))
-* **New Resource:** `platform_secret_file` ([#157](https://github.com/hashicorp/terraform-provider-harness/issues/157))
-* **New Resource:** `platform_secret_sshkey` ([#159](https://github.com/hashicorp/terraform-provider-harness/issues/159))
-* **New Resource:** `platform_secret_text` ([#154](https://github.com/hashicorp/terraform-provider-harness/issues/154))
+* **New Resource:** `platform_roles` ([#161](https://github.com/harness/terraform-provider-harness/issues/161))
+* **New Resource:** `platform_secret_file` ([#157](https://github.com/harness/terraform-provider-harness/issues/157))
+* **New Resource:** `platform_secret_sshkey` ([#159](https://github.com/harness/terraform-provider-harness/issues/159))
+* **New Resource:** `platform_secret_text` ([#154](https://github.com/harness/terraform-provider-harness/issues/154))
 
 # 0.2.11
 
@@ -25,129 +25,129 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* resource/application: Added support for tagging. ([#140](https://github.com/hashicorp/terraform-provider-harness/issues/140))
+* resource/application: Added support for tagging. ([#140](https://github.com/harness/terraform-provider-harness/issues/140))
 
 # 0.2.8
 
 ENHANCEMENTS:
 
-* Upgraded harnes-go-sdk@v0.2.27 ([#139](https://github.com/hashicorp/terraform-provider-harness/issues/139))
+* Upgraded harnes-go-sdk@v0.2.27 ([#139](https://github.com/harness/terraform-provider-harness/issues/139))
 
 BUG FIXES:
 
-* datasource/harness_platform_connector: Fixed lookup by name. ([#139](https://github.com/hashicorp/terraform-provider-harness/issues/139))
-* datasource/harness_platform_organization: Fixed lookup by name. ([#139](https://github.com/hashicorp/terraform-provider-harness/issues/139))
-* datasource/harness_platform_pipeline: Fixed lookup by name. ([#139](https://github.com/hashicorp/terraform-provider-harness/issues/139))
-* datasource/harness_platform_project: Fixed lookup by name. ([#139](https://github.com/hashicorp/terraform-provider-harness/issues/139))
+* datasource/harness_platform_connector: Fixed lookup by name. ([#139](https://github.com/harness/terraform-provider-harness/issues/139))
+* datasource/harness_platform_organization: Fixed lookup by name. ([#139](https://github.com/harness/terraform-provider-harness/issues/139))
+* datasource/harness_platform_pipeline: Fixed lookup by name. ([#139](https://github.com/harness/terraform-provider-harness/issues/139))
+* datasource/harness_platform_project: Fixed lookup by name. ([#139](https://github.com/harness/terraform-provider-harness/issues/139))
 
 # 0.2.7
 
 BUG FIXES:
 
-* Fixed issue with serializing encrypted text references with environment variable overrides. ([#131](https://github.com/hashicorp/terraform-provider-harness/issues/131))
+* Fixed issue with serializing encrypted text references with environment variable overrides. ([#131](https://github.com/harness/terraform-provider-harness/issues/131))
 
 # 0.2.6
 
 BUG FIXES:
 
-* Fixed issue with serializing encrypted text references with service variables. ([#128](https://github.com/hashicorp/terraform-provider-harness/issues/128))
+* Fixed issue with serializing encrypted text references with service variables. ([#128](https://github.com/harness/terraform-provider-harness/issues/128))
 
 # 0.2.4
 
 BUG FIXES:
 
-* resource/cloudprovider_kubernetes: Fixes issue causing delegate selectors to not be applied properly. ([#123](https://github.com/hashicorp/terraform-provider-harness/issues/123))
+* resource/cloudprovider_kubernetes: Fixes issue causing delegate selectors to not be applied properly. ([#123](https://github.com/harness/terraform-provider-harness/issues/123))
 
 # 0.2.3
 
 FEATURES:
 
-* **New Data Source:** `current_account` ([#119](https://github.com/hashicorp/terraform-provider-harness/issues/119))
+* **New Data Source:** `current_account` ([#119](https://github.com/harness/terraform-provider-harness/issues/119))
 
 ENHANCEMENTS:
 
-* data-source/yaml_config: Changing `path` field forces a new resource to be created. ([#117](https://github.com/hashicorp/terraform-provider-harness/issues/117))
+* data-source/yaml_config: Changing `path` field forces a new resource to be created. ([#117](https://github.com/harness/terraform-provider-harness/issues/117))
 
 BUG FIXES:
 
-* resource/delegate_approval: Force new resource when `delegate_id` or `approve` fields change. ([#115](https://github.com/hashicorp/terraform-provider-harness/issues/115))
+* resource/delegate_approval: Force new resource when `delegate_id` or `approve` fields change. ([#115](https://github.com/harness/terraform-provider-harness/issues/115))
 
 # 0.2.2
 
 FEATURES:
 
-* **New Data Source:** `platform_connector_appdynamics` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_artifactory` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_aws` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_aws_secret_m` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_awscc` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_awskms` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_bitbucket` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_datadog` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_docker` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_dynatrace` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_gcp` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_git` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_github` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_gitlab` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_helm` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_jira` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_kubernetes` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_nexus` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_pagerduty` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_prometheus` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_splunk` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_connector_sumologic` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_current_user` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_environment` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_organization` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_pipeline` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_project` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Data Source:** `platform_service` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_appdynamics` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_artifactory` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_aws` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_aws_secret_manager` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_awscc` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_awskms` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_bitbucket` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_datadog` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_docker` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_dynatrace` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_gcp` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_git` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_github` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_gitlab` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_helm` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_jira` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_kubernetes` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_nexus` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_pagerduty` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_prometheus` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_splunk` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_connector_sumologic` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_current_user` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_environment` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_organization` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_pipeline` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_project` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
-* **New Resource:** `platform_service` ([#112](https://github.com/hashicorp/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_appdynamics` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_artifactory` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_aws` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_aws_secret_m` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_awscc` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_awskms` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_bitbucket` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_datadog` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_docker` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_dynatrace` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_gcp` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_git` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_github` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_gitlab` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_helm` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_jira` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_kubernetes` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_nexus` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_pagerduty` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_prometheus` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_splunk` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_connector_sumologic` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_current_user` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_environment` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_organization` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_pipeline` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_project` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Data Source:** `platform_service` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_appdynamics` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_artifactory` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_aws` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_aws_secret_manager` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_awscc` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_awskms` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_bitbucket` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_datadog` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_docker` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_dynatrace` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_gcp` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_git` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_github` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_gitlab` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_helm` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_jira` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_kubernetes` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_nexus` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_pagerduty` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_prometheus` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_splunk` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_connector_sumologic` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_current_user` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_environment` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_organization` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_pipeline` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_project` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
+* **New Resource:** `platform_service` ([#112](https://github.com/harness/terraform-provider-harness/issues/112))
 
 # 0.2.1
 
 BUG FIXES:
 
-* Fixes issue deleted account-level yaml config resources ([#106](https://github.com/hashicorp/terraform-provider-harness/issues/106))
+* Fixes issue deleted account-level yaml config resources ([#106](https://github.com/harness/terraform-provider-harness/issues/106))
 
 # 0.2.0
 
 BREAKING CHANGES:
 
-* Separate Nextgen codebase and Current Gen codebase ([#98](https://github.com/hashicorp/terraform-provider-harness/issues/98))
+* Separate Nextgen codebase and Current Gen codebase ([#98](https://github.com/harness/terraform-provider-harness/issues/98))
 
 ENHANCEMENTS:
 
-* Upgraded to golang 1.17 ([#98](https://github.com/hashicorp/terraform-provider-harness/issues/98))
+* Upgraded to golang 1.17 ([#98](https://github.com/harness/terraform-provider-harness/issues/98))
 
 # 0.1.16
 
@@ -155,28 +155,28 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-* Fixes issue with config-as-code secret references. ([#89](https://github.com/hashicorp/terraform-provider-harness/issues/89))
+* Fixes issue with config-as-code secret references. ([#89](https://github.com/harness/terraform-provider-harness/issues/89))
 
 # 0.1.14
 
 ENHANCEMENTS:
 
-* data-source/harness_environment: Replaces `id` field with `environment_id` so `id` field can be marked as computed. ([#81](https://github.com/hashicorp/terraform-provider-harness/issues/81))
+* data-source/harness_environment: Replaces `id` field with `environment_id` so `id` field can be marked as computed. ([#81](https://github.com/harness/terraform-provider-harness/issues/81))
 
 # 0.1.13
 
 FEATURES:
 
-* **New Resource:** `user_group_permissions` ([#80](https://github.com/hashicorp/terraform-provider-aws/issues/80))
+* **New Resource:** `user_group_permissions` ([#80](https://github.com/harness/terraform-provider-aws/issues/80))
 
 ENHANCEMENTS:
 
-* data-source/harness_current_user: Change `2fa_enabled` to `is_two_factor_auth_enabled` to support `cdk` usage. ([#75](https://github.com/hashicorp/terraform-provider-harness/issues/75))
+* data-source/harness_current_user: Change `2fa_enabled` to `is_two_factor_auth_enabled` to support `cdk` usage. ([#75](https://github.com/harness/terraform-provider-harness/issues/75))
 
 BUG FIXES:
 
-* Added configuration for auto generating the changelog ([#78](https://github.com/hashicorp/terraform-provider-harness/issues/78))
-* Fixed missing nextgen auth configuration in the provider. ([#76](https://github.com/hashicorp/terraform-provider-harness/issues/76))
+* Added configuration for auto generating the changelog ([#78](https://github.com/harness/terraform-provider-harness/issues/78))
+* Fixed missing nextgen auth configuration in the provider. ([#76](https://github.com/harness/terraform-provider-harness/issues/76))
 
 # 0.1.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ ENHANCEMENTS:
 
 FEATURES:
 
-* **New Resource:** `user_group_permissions` ([#80](https://github.com/harness/terraform-provider-aws/issues/80))
+* **New Resource:** `user_group_permissions` ([#80](https://github.com/harness/terraform-provider-harness/issues/80))
 
 ENHANCEMENTS:
 

--- a/scripts/release-note.tmpl
+++ b/scripts/release-note.tmpl
@@ -1,11 +1,11 @@
 {{- define "note" -}}
 {{- if eq "new-resource" .Type -}}
-* **New Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-harness/issues/{{- .Issue -}}))
+* **New Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/harness/terraform-provider-harness/issues/{{- .Issue -}}))
 {{- else if eq "new-data-source" .Type -}}
-* **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-harness/issues/{{- .Issue -}}))
+* **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/harness/terraform-provider-harness/issues/{{- .Issue -}}))
 {{- else if eq "new-guide" .Type -}}
-* **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-harness/issues/{{- .Issue -}}))
+* **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/harness/terraform-provider-harness/issues/{{- .Issue -}}))
 {{- else -}}
-* {{.Body}} ([#{{- .Issue -}}](https://github.com/hashicorp/terraform-provider-harness/issues/{{- .Issue -}}))
+* {{.Body}} ([#{{- .Issue -}}](https://github.com/harness/terraform-provider-harness/issues/{{- .Issue -}}))
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Issue links in the `CHANGELOG.md` file are pointing at the HashiCorp GitHub repository. This change updates the links to point at the Harness repository and fixes the template used to generate the file.