### PR TITLE
Fix deletion of project and org level connectors

### DIFF
--- a/internal/service/platform/connector/connector.go
+++ b/internal/service/platform/connector/connector.go
@@ -83,12 +83,26 @@ func resourceConnectorCreateOrUpdateBase(ctx context.Context, d *schema.Resource
 func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 
-	_, _, err := c.ConnectorsApi.DeleteConnector(ctx, c.AccountId, d.Id(), &nextgen.ConnectorsApiDeleteConnectorOpts{})
+	_, _, err := c.ConnectorsApi.DeleteConnector(ctx, c.AccountId, d.Id(), getDeleteConnectorOpts(d))
 	if err != nil {
 		return diag.Errorf(err.(nextgen.GenericSwaggerError).Error())
 	}
 
 	return nil
+}
+
+func getDeleteConnectorOpts(d *schema.ResourceData) *nextgen.ConnectorsApiDeleteConnectorOpts {
+	connOpts := &nextgen.ConnectorsApiDeleteConnectorOpts{}
+
+	if attr, ok := d.GetOk("org_id"); ok {
+		connOpts.OrgIdentifier = optional.NewString(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("project_id"); ok {
+		connOpts.ProjectIdentifier = optional.NewString(attr.(string))
+	}
+
+	return connOpts
 }
 
 func buildConnector(d *schema.ResourceData, connector *nextgen.ConnectorInfo) {


### PR DESCRIPTION
Currently terraform fails to delete connectors that are at the org and project level because the identifiers aren't sent in the DELETE request.
This change includes them in the opts so that they're included in the query params.