### PR TITLE
fixing issue with the example document for harness_platform_organzarion

### DIFF
--- a/examples/resources/harness_platform_organization/resource.tf
+++ b/examples/resources/harness_platform_organization/resource.tf
@@ -1,4 +1,4 @@
-resource "harness_organization" "this" {
+resource "harness_platform_organization" "this" {
   identifier  = "MyOrg"
   name        = "My Otganization"
   description = "An example organization"


### PR DESCRIPTION
│ Error: Invalid resource type
│
│   on organizaion.tf line 1, in resource "harness_organization" "test":
│    1: resource "harness_organization" "test" {
│
│ The provider harness/harness does not support resource type "harness_organization

## Describe your changes

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
