### PR TITLE
fix: [PL-31990]: Get Id field from get call and not make it null for roleAssignments

### DIFF
--- a/internal/service/platform/role_assignments/role_assignments.go
+++ b/internal/service/platform/role_assignments/role_assignments.go
@@ -27,6 +27,7 @@ func ResourceRoleAssignments() *schema.Resource {
 				Description: "Identifier for role assignment.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"resource_group_identifier": {
 				Description: "Resource group identifier.",

--- a/internal/service/platform/role_assignments/role_assignments_test.go
+++ b/internal/service/platform/role_assignments/role_assignments_test.go
@@ -57,6 +57,38 @@ func TestAccRoleAssignments(t *testing.T) {
 	})
 }
 
+func TestAccRoleAssignments_withoutSendingIdentifier(t *testing.T) {
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	resourceName := "harness_platform_role_assignments.test"
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccRoleAssignmentsDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRoleAssignments_withoutIdentifier(id, name, "false", accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "identifier"),
+					resource.TestCheckResourceAttr(resourceName, "resource_group_identifier", "_all_project_level_resources"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "principal.0.type", "SERVICE_ACCOUNT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceRoleAssignments_DeleteUnderlyingResource(t *testing.T) {
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
 	name := id
@@ -167,6 +199,53 @@ func testAccResourceRoleAssignments(id string, name string, disabled string, acc
 
 	resource "harness_platform_role_assignments" "test"{
 		identifier = "%[1]s"
+		org_id = harness_platform_project.test.org_id
+		project_id = harness_platform_project.test.id
+		resource_group_identifier = "_all_project_level_resources"
+		role_identifier = harness_platform_roles.test.id
+		principal {
+			identifier = harness_platform_service_account.test.id
+			type = "SERVICE_ACCOUNT"
+		}
+		disabled = %[3]s
+		managed = false
+	}
+	`, id, name, disabled, accountId)
+}
+
+func testAccResourceRoleAssignments_withoutIdentifier(id string, name string, disabled string, accountId string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		color = "#0063F7"
+		org_id = harness_platform_organization.test.identifier
+	}
+	resource "harness_platform_service_account" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		email = "email@service.harness.io"
+		description = "test"
+		tags = ["foo:bar"]
+		account_id = "%[4]s"
+		org_id = harness_platform_project.test.org_id
+		project_id = harness_platform_project.test.id
+	}
+	resource "harness_platform_roles" "test" {
+		org_id = harness_platform_project.test.org_id
+		project_id = harness_platform_project.test.id
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		permissions = ["core_pipeline_edit"]
+		allowed_scope_levels = ["project"]
+	}
+	resource "harness_platform_role_assignments" "test"{
 		org_id = harness_platform_project.test.org_id
 		project_id = harness_platform_project.test.id
 		resource_group_identifier = "_all_project_level_resources"


### PR DESCRIPTION
## Describe your changes

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
