### PR TITLE
Coverage Increased For PL Owned Entities

### DIFF
--- a/internal/service/platform/connector/aws_kms_test.go
+++ b/internal/service/platform/connector/aws_kms_test.go
@@ -57,6 +57,104 @@ func TestAccResourceConnectorAwsKms_inherit(t *testing.T) {
 	})
 }
 
+func TestProjectResourceConnectorAwsKms_inherit(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsKms_inherit(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsKms_inherit(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorAwsKms_inherit(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsKms_inherit(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsKms_inherit(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceConnectorAwsKms_manual(t *testing.T) {
 
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
@@ -98,6 +196,100 @@ func TestAccResourceConnectorAwsKms_manual(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestProjectResourceConnectorAwsKms_manual(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsKms_manual(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsKms_manual(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorAwsKms_manual(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsKms_manual(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsKms_manual(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -155,6 +347,112 @@ func TestAccResourceConnectorAwsKms_assumerole(t *testing.T) {
 	})
 }
 
+func TestProjectResourceConnectorAwsKms_assumerole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsKms_assumerole(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsKms_assumerole(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorAwsKms_assumerole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_awskms.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsKms_assumerole(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsKms_assumerole(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorAwsKms_inherit(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -187,6 +485,107 @@ func testAccResourceConnectorAwsKms_inherit(id string, name string) string {
 			depends_on = [harness_platform_secret_text.test]
 			destroy_duration = "4s"
 		}
+`, id, name)
+}
+
+func testProjectResourceConnectorAwsKms_inherit(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id=harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "4s" 
+	}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id=harness_platform_organization.test.id
+			project_id=harness_platform_project.test.id
+			arn_ref = "${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				inherit_from_delegate = true
+			}
+			depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "3s" 
+	}
+`, id, name)
+}
+
+func testOrgResourceConnectorAwsKms_inherit(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id=harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s" 
+	}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id=harness_platform_organization.test.id
+			arn_ref = "org.${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				inherit_from_delegate = true
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s" 
+	}
 `, id, name)
 }
 
@@ -224,7 +623,115 @@ func testAccResourceConnectorAwsKms_manual(id string, name string) string {
 
 		resource "time_sleep" "wait_4_seconds" {
 			depends_on = [harness_platform_secret_text.test]
-			destroy_duration = "4s"
+			create_duration = "4s"
+		}
+`, id, name)
+}
+
+func testProjectResourceConnectorAwsKms_manual(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id=harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+		}
+
+		resource "time_sleep" "wait_3_seconds" {
+			depends_on = [harness_platform_project.test]
+			create_duration = "3s"
+		}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id=harness_platform_organization.test.id
+			project_id=harness_platform_project.test.id
+			arn_ref = "${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				manual {
+					secret_key_ref = "${harness_platform_secret_text.test.id}"
+					access_key_ref = "${harness_platform_secret_text.test.id}"
+				}
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name)
+}
+
+func testOrgResourceConnectorAwsKms_manual(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id=harness_platform_organization.test.id
+		
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+		}
+
+		resource "time_sleep" "wait_3_seconds" {
+			depends_on = [harness_platform_organization.test]
+			create_duration = "3s"
+		}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id=harness_platform_organization.test.id
+			arn_ref = "org.${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				manual {
+					secret_key_ref = "org.${harness_platform_secret_text.test.id}"
+					access_key_ref = "org.${harness_platform_secret_text.test.id}"
+				}
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
 		}
 `, id, name)
 }
@@ -264,6 +771,115 @@ func testAccResourceConnectorAwsKms_assumerole(id string, name string) string {
 		resource "time_sleep" "wait_4_seconds" {
 			depends_on = [harness_platform_secret_text.test]
 			destroy_duration = "4s"
+		}
+`, id, name)
+}
+
+func testProjectResourceConnectorAwsKms_assumerole(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id= harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+		}
+
+		resource "time_sleep" "wait_3_seconds" {
+			depends_on = [harness_platform_project.test]
+			create_duration = "3s"
+		}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			arn_ref = "${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				assume_role {
+					role_arn = "somerolearn"
+					external_id = "externalid"
+					duration = 900
+				}
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			destroy_duration = "4s"
+		}
+`, id, name)
+}
+
+func testOrgResourceConnectorAwsKms_assumerole(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id=harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+		}
+
+		resource "time_sleep" "wait_3_seconds" {
+			depends_on = [harness_platform_organization.test]
+			create_duration = "3s"
+		}
+
+		resource "harness_platform_connector_awskms" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id=harness_platform_organization.test.id
+			arn_ref = "org.${harness_platform_secret_text.test.id}"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				assume_role {
+					role_arn = "somerolearn"
+					external_id = "externalid"
+					duration = 900
+				}
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
 		}
 `, id, name)
 }

--- a/internal/service/platform/connector/aws_secret_manager_test.go
+++ b/internal/service/platform/connector/aws_secret_manager_test.go
@@ -55,6 +55,100 @@ func TestAccResourceConnectorAwsSM_inherit(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorAwsSM_inherit(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsSM_inherit(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsSM_inherit(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorAwsSM_inherit(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsSM_inherit(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsSM_inherit(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.inherit_from_delegate", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 func TestAccResourceConnectorAwsSM_manual(t *testing.T) {
 
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
@@ -98,6 +192,102 @@ func TestAccResourceConnectorAwsSM_manual(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestProjectResourceConnectorAwsSM_manual(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsSM_manual(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsSM_manual(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorAwsSM_manual(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsSM_manual(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsSM_manual(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -153,6 +343,108 @@ func TestAccResourceConnectorAwsSM_assumerole(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorAwsSM_assumerole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAwsSM_assumerole(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAwsSM_assumerole(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorAwsSM_assumerole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_aws_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAwsSM_assumerole(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAwsSM_assumerole(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_name_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.role_arn", "somerolearn"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.external_id", "externalid"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.assume_role.0.duration", "900"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func testAccResourceConnectorAwsSM_inherit(id string, name string) string {
 	return fmt.Sprintf(`
@@ -162,6 +454,58 @@ func testAccResourceConnectorAwsSM_inherit(id string, name string) string {
 			description = "test"
 			tags = ["foo:bar"]
 
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				inherit_from_delegate = true
+			}
+		}
+`, id, name)
+}
+
+func testProjectResourceConnectorAwsSM_inherit(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				inherit_from_delegate = true
+			}
+		}
+`, id, name)
+}
+
+func testOrgResourceConnectorAwsSM_inherit(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
 			secret_name_prefix = "test"
 			region = "us-east-1"
 			delegate_selectors = ["harness-delegate"]
@@ -209,6 +553,111 @@ func testAccResourceConnectorAwsSM_manual(id string, name string) string {
 		}
 `, id, name)
 }
+func testProjectResourceConnectorAwsSM_manual(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
+		project_id = harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_project.test]
+			create_duration = "4s"
+		}
+
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				manual {
+					secret_key_ref = "${harness_platform_secret_text.test.id}"
+					access_key_ref = "${harness_platform_secret_text.test.id}"
+				}
+			}
+			depends_on = [time_sleep.wait_5_seconds]
+		}
+
+		resource "time_sleep" "wait_5_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "5s"
+		}
+`, id, name)
+}
+func testOrgResourceConnectorAwsSM_manual(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+		resource "time_sleep" "wait_3_seconds" {
+			depends_on = [harness_platform_organization.test]
+			create_duration = "3s"
+		}
+
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				manual {
+					secret_key_ref = "org.${harness_platform_secret_text.test.id}"
+					access_key_ref = "org.${harness_platform_secret_text.test.id}"
+				}
+			}
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name)
+}
 
 func testAccResourceConnectorAwsSM_assumerole(id string, name string) string {
 	return fmt.Sprintf(`
@@ -218,6 +667,67 @@ func testAccResourceConnectorAwsSM_assumerole(id string, name string) string {
 			description = "test"
 			tags = ["foo:bar"]
 
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				assume_role {
+					role_arn = "somerolearn"
+					external_id = "externalid"
+					duration = 900
+				}
+			}
+		}
+`, id, name)
+}
+
+func testProjectResourceConnectorAwsSM_assumerole(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			secret_name_prefix = "test"
+			region = "us-east-1"
+			delegate_selectors = ["harness-delegate"]
+			credentials {
+				assume_role {
+					role_arn = "somerolearn"
+					external_id = "externalid"
+					duration = 900
+				}
+			}
+		}
+`, id, name)
+}
+
+func testOrgResourceConnectorAwsSM_assumerole(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+		resource "harness_platform_connector_aws_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
 			secret_name_prefix = "test"
 			region = "us-east-1"
 			delegate_selectors = ["harness-delegate"]

--- a/internal/service/platform/connector/aws_secret_manager_test.go
+++ b/internal/service/platform/connector/aws_secret_manager_test.go
@@ -224,7 +224,7 @@ func TestProjectResourceConnectorAwsSM_manual(t *testing.T) {
 				),
 			},
 			{
-				Config: testProjectResourceConnectorAwsSM_manual(id, name),
+				Config: testProjectResourceConnectorAwsSM_manual(id, updatedName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),

--- a/internal/service/platform/connector/azure_key_vault_test.go
+++ b/internal/service/platform/connector/azure_key_vault_test.go
@@ -57,6 +57,104 @@ func TestAccResourceConnectorAzureKeyVault(t *testing.T) {
 	})
 }
 
+func TestProjectResourceConnectorAzureKeyVault(t *testing.T) {
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_azure_key_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorAzureKeyVault(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_id", "b229b2bb-5f33-4d22-bce0-730f6474e906"),
+					resource.TestCheckResourceAttr(resourceName, "subscription", "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"),
+					resource.TestCheckResourceAttr(resourceName, "vault_name", "Aman-test"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorAzureKeyVault(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_id", "b229b2bb-5f33-4d22-bce0-730f6474e906"),
+					resource.TestCheckResourceAttr(resourceName, "subscription", "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"),
+					resource.TestCheckResourceAttr(resourceName, "vault_name", "Aman-test"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorAzureKeyVault(t *testing.T) {
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_azure_key_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorAzureKeyVault(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_id", "b229b2bb-5f33-4d22-bce0-730f6474e906"),
+					resource.TestCheckResourceAttr(resourceName, "subscription", "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"),
+					resource.TestCheckResourceAttr(resourceName, "vault_name", "Aman-test"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorAzureKeyVault(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_id", "b229b2bb-5f33-4d22-bce0-730f6474e906"),
+					resource.TestCheckResourceAttr(resourceName, "subscription", "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"),
+					resource.TestCheckResourceAttr(resourceName, "vault_name", "Aman-test"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorAzureKeyVault(id string, name string) string {
 	return fmt.Sprintf(`
 
@@ -66,6 +164,65 @@ func testAccResourceConnectorAzureKeyVault(id string, name string) string {
 		description = "test"
 		tags = ["foo:bar"]
 
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+	}
+`, id, name)
+}
+
+func testProjectResourceConnectorAzureKeyVault(id string, name string) string {
+	return fmt.Sprintf(`
+
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
+		project_id = harness_platform_project.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+	}
+`, id, name)
+}
+
+func testOrgResourceConnectorAzureKeyVault(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
 		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
 		secret_key = "account.azuretest"
 		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"

--- a/internal/service/platform/connector/gcp_secret_manager_test.go
+++ b/internal/service/platform/connector/gcp_secret_manager_test.go
@@ -57,6 +57,106 @@ func TestAccResourceConnectorGcpSM(t *testing.T) {
 	})
 }
 
+func TestProjectResourceConnectorGcpSM(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_gcp_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorGcpSM(id, name,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorGcpSM(id, updatedName,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorGcpSM(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_gcp_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorGcpSM(id, name,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorGcpSM(id, updatedName,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceConnectorGcpSMDefault(t *testing.T) {
 
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
@@ -104,6 +204,104 @@ func TestAccResourceConnectorGcpSMDefault(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorGcpSMDefault(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_gcp_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorGcpSMDefault(id, name,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorGcpSMDefault(id, updatedName,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorGcpSMDefault(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_gcp_secret_manager.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorGcpSMDefault(id, name,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorGcpSMDefault(id, updatedName,connectorName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "is_default", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func testAccResourceConnectorGcpSM(id string, name string) string {
 	return fmt.Sprintf(`
@@ -135,6 +333,142 @@ func testAccResourceConnectorGcpSM(id string, name string) string {
 `, id, name)
 }
 
+func testProjectResourceConnectorGcpSM(id string, name string,connectorName string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[3]s"
+		name = "%[3]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "3s"
+	}
+		resource "harness_platform_secret_text" "test" {
+			identifier = "%[1]s"
+			name = "%[1]s"
+			description = "test"
+			org_id= harness_platform_organization.test.id
+			project_id=harness_platform_project.test.id
+			tags = ["foo:bar"]
+			secret_manager_identifier = "%[3]s"
+			value_type = "Reference"
+			value = "secret"
+			depends_on = [time_sleep.wait_5_seconds]
+	}
+
+	resource "time_sleep" "wait_5_seconds" {
+		depends_on = [harness_platform_connector_azure_key_vault.test]
+		create_duration = "5s"
+	}
+
+		resource "harness_platform_connector_gcp_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			delegate_selectors = ["harness-delegate"]
+			credentials_ref = "${harness_platform_secret_text.test.id}"
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name,connectorName)
+}
+
+func testOrgResourceConnectorGcpSM(id string, name string,connectorName string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[3]s"
+		name = "%[3]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s"
+	}
+		resource "harness_platform_secret_text" "test" {
+			identifier = "%[1]s"
+			name = "%[1]s"
+			description = "test"
+			org_id= harness_platform_organization.test.id
+			tags = ["foo:bar"]
+			secret_manager_identifier = "%[3]s"
+			value_type = "Reference"
+			value = "secret"
+			depends_on = [time_sleep.wait_5_seconds]
+		}
+
+		resource "time_sleep" "wait_5_seconds" {
+			depends_on = [harness_platform_connector_azure_key_vault.test]
+			create_duration = "5s"
+		}
+
+		resource "harness_platform_connector_gcp_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			delegate_selectors = ["harness-delegate"]
+			credentials_ref = "org.${harness_platform_secret_text.test.id}"
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name,connectorName)
+}
+
 func testAccResourceConnectorGcpSMDefault(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_secret_text" "test" {
@@ -164,4 +498,139 @@ func testAccResourceConnectorGcpSMDefault(id string, name string) string {
 			destroy_duration = "4s"
 		}
 `, id, name)
+}
+
+func testProjectResourceConnectorGcpSMDefault(id string, name string,connectorName string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[3]s"
+		name = "%[3]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "3s"
+	}
+		resource "harness_platform_secret_text" "test" {
+			identifier = "%[1]s"
+			name = "%[1]s"
+			description = "test"
+			org_id= harness_platform_organization.test.id
+			project_id=harness_platform_project.test.id
+			tags = ["foo:bar"]
+			secret_manager_identifier = "%[3]s"
+			value_type = "Reference"
+			value = "secret"
+			depends_on = [time_sleep.wait_5_seconds]
+	}
+
+	resource "time_sleep" "wait_5_seconds" {
+		depends_on = [harness_platform_connector_azure_key_vault.test]
+		create_duration = "5s"
+	}
+
+		resource "harness_platform_connector_gcp_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			delegate_selectors = ["harness-delegate"]
+			credentials_ref = "${harness_platform_secret_text.test.id}"
+			is_default = true
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name,connectorName)
+}
+
+func testOrgResourceConnectorGcpSMDefault(id string, name string,connectorName string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[3]s"
+		name = "%[3]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s"
+	}
+		resource "harness_platform_secret_text" "test" {
+			identifier = "%[1]s"
+			name = "%[1]s"
+			description = "test"
+			org_id= harness_platform_organization.test.id
+			tags = ["foo:bar"]
+			secret_manager_identifier = "%[3]s"
+			value_type = "Reference"
+			value = "secret"
+			depends_on = [time_sleep.wait_5_seconds]
+		}
+
+		resource "time_sleep" "wait_5_seconds" {
+			depends_on = [harness_platform_connector_azure_key_vault.test]
+			create_duration = "5s"
+		}
+
+		resource "harness_platform_connector_gcp_secret_manager" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			delegate_selectors = ["harness-delegate"]
+			is_default = true
+			credentials_ref = "org.${harness_platform_secret_text.test.id}"
+			depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_secret_text.test]
+			create_duration = "4s"
+		}
+`, id, name,connectorName)
 }

--- a/internal/service/platform/connector/pagerduty_test.go
+++ b/internal/service/platform/connector/pagerduty_test.go
@@ -19,9 +19,6 @@ func TestAccResourceConnectorPagerduty(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.TestAccPreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		CheckDestroy: testAccConnectorDestroy(resourceName),
 		Steps: []resource.TestStep{
 			{
@@ -55,6 +52,100 @@ func TestAccResourceConnectorPagerduty(t *testing.T) {
 	})
 }
 
+func TestProjectResourceConnectorPagerduty(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_pagerduty.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorPagerduty(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorPagerduty(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestOrgResourceConnectorPagerduty(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_pagerduty.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorPagerduty(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorPagerduty(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorPagerduty(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -76,13 +167,87 @@ func testAccResourceConnectorPagerduty(id string, name string) string {
 
 			delegate_selectors = ["harness-delegate"]
 			api_token_ref = "account.${harness_platform_secret_text.test.id}"
+		}
+`, id, name)
+}
 
-			depends_on = [time_sleep.wait_4_seconds]
+func testProjectResourceConnectorPagerduty(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_4_seconds]
 		}
 
 		resource "time_sleep" "wait_4_seconds" {
-			depends_on = [harness_platform_secret_text.test]
-			destroy_duration = "4s"
+			depends_on = [harness_platform_project.test]
+			create_duration = "4s"
+		}
+
+		resource "harness_platform_connector_pagerduty" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			delegate_selectors = ["harness-delegate"]
+			api_token_ref = "${harness_platform_secret_text.test.id}"
+		}
+`, id, name)
+}
+
+func testOrgResourceConnectorPagerduty(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+		depends_on = [time_sleep.wait_4_seconds]
+		}
+
+		resource "time_sleep" "wait_4_seconds" {
+			depends_on = [harness_platform_organization.test]
+			create_duration = "4s"
+		}
+
+		resource "harness_platform_connector_pagerduty" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+			org_id= harness_platform_organization.test.id
+			delegate_selectors = ["harness-delegate"]
+			api_token_ref = "org.${harness_platform_secret_text.test.id}"
 		}
 `, id, name)
 }

--- a/internal/service/platform/connector/vault_test.go
+++ b/internal/service/platform/connector/vault_test.go
@@ -64,6 +64,114 @@ func TestAccResourceConnectorVault_Token(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorVault_Token(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorVault_token(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "harness"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "TOKEN"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorVault_token(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "harness"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "TOKEN"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorVault_Token(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorVault_token(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "harness"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "TOKEN"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorVault_token(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "harness"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "TOKEN"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func TestAccResourceConnectorVault_VaultAgent(t *testing.T) {
 
@@ -122,6 +230,122 @@ func TestAccResourceConnectorVault_VaultAgent(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorVault_VaultAgent(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorVault_vault_agent(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sink_path", "sink_path"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "VAULT_AGENT"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorVault_vault_agent(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sink_path", "sink_path"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "VAULT_AGENT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorVault_VaultAgent(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorVault_vault_agent(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sink_path", "sink_path"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "VAULT_AGENT"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorVault_vault_agent(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sink_path", "sink_path"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "VAULT_AGENT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func TestAccResourceConnectorVault_K8sAuth(t *testing.T) {
 
@@ -174,6 +398,118 @@ func TestAccResourceConnectorVault_K8sAuth(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestProjectResourceConnectorVault_K8sAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorVault_k8s_auth(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "K8s_AUTH"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorVault_k8s_auth(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "K8s_AUTH"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorVault_K8sAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorVault_k8s_auth(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "K8s_AUTH"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorVault_k8s_auth(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "base_path"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "K8s_AUTH"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -235,6 +571,120 @@ func TestAccResourceConnectorVault_AppRole(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorVault_AppRole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+	vault_sercet := os.Getenv("HARNESS_TEST_VAULT_SECRET")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorVault_app_role(id, name, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "APP_ROLE"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorVault_app_role(id, updatedName, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "APP_ROLE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorVault_AppRole(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+	vault_sercet := os.Getenv("HARNESS_TEST_VAULT_SECRET")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorVault_app_role(id, name, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "APP_ROLE"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorVault_app_role(id, updatedName, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "APP_ROLE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func TestAccResourceConnectorVault_AwsAuth(t *testing.T) {
 
@@ -292,6 +742,120 @@ func TestAccResourceConnectorVault_AwsAuth(t *testing.T) {
 		},
 	})
 }
+func TestProjectResourceConnectorVault_AwsAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+	vault_sercet := os.Getenv("HARNESS_TEST_VAULT_SECRET")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceConnectorVault_aws_auth(id, name, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "AWS_IAM"),
+				),
+			},
+			{
+				Config: testProjectResourceConnectorVault_aws_auth(id, updatedName, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "AWS_IAM"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+func TestOrgResourceConnectorVault_AwsAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_vault.test"
+	vault_sercet := os.Getenv("HARNESS_TEST_VAULT_SECRET")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceConnectorVault_aws_auth(id, name, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "AWS_IAM"),
+				),
+			},
+			{
+				Config: testOrgResourceConnectorVault_aws_auth(id, updatedName, vault_sercet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "base_path", "vikas-test/"),
+					resource.TestCheckResourceAttr(resourceName, "is_read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "renewal_interval_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "secret_engine_manually_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_vault_agent", "false"),
+					resource.TestCheckResourceAttr(resourceName, "access_type", "AWS_IAM"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
 
 func testAccResourceConnectorVault_aws_auth(id string, name string, vault_secret string) string {
 	return fmt.Sprintf(`
@@ -340,6 +904,139 @@ func testAccResourceConnectorVault_aws_auth(id string, name string, vault_secret
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
 		destroy_duration = "4s"
+	}
+	`, id, name, vault_secret)
+}
+
+func testProjectResourceConnectorVault_aws_auth(id string, name string, vault_secret string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		lifecycle {
+			ignore_changes = [
+				value,
+			]
+		}
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "4s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		aws_region = "us-east-2"
+		base_path = "vikas-test/"
+		access_type = "AWS_IAM"
+		default = false
+		xvault_aws_iam_server_id = "${harness_platform_secret_text.test.id}"
+		read_only = true
+		renewal_interval_minutes = 60
+		secret_engine_manually_configured = true
+		secret_engine_name = "harness-test"
+		secret_engine_version = 2
+		vault_aws_iam_role = "570acf09-ef2a-144b-2fb0-14a42e06ffe3"
+		use_aws_iam = true
+		use_k8s_auth = false
+		use_vault_agent = false
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "3s"
+	}
+	`, id, name, vault_secret)
+}
+
+func testOrgResourceConnectorVault_aws_auth(id string, name string, vault_secret string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		lifecycle {
+			ignore_changes = [
+				value,
+			]
+		}
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_organization.test]
+		destroy_duration = "3s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		aws_region = "us-east-2"
+		base_path = "vikas-test/"
+		access_type = "AWS_IAM"
+		default = false
+		xvault_aws_iam_server_id = "org.${harness_platform_secret_text.test.id}"
+		read_only = true
+		renewal_interval_minutes = 60
+		secret_engine_manually_configured = true
+		secret_engine_name = "harness-test"
+		secret_engine_version = 2
+		vault_aws_iam_role = "570acf09-ef2a-144b-2fb0-14a42e06ffe3"
+		use_aws_iam = true
+		use_k8s_auth = false
+		use_vault_agent = false
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s"
 	}
 	`, id, name, vault_secret)
 }
@@ -393,6 +1090,135 @@ func testAccResourceConnectorVault_app_role(id string, name string, vault_secret
 	}
 	`, id, name, vault_secret)
 }
+func testProjectResourceConnectorVault_app_role(id string, name string, vault_secret string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		lifecycle {
+			ignore_changes = [
+				value,
+			]
+		}
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "4s"
+	}
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		app_role_id = "570acf09-ef2a-144b-2fb0-14a42e06ffe3"
+		base_path = "vikas-test/"
+		access_type = "APP_ROLE"
+		default = false
+		secret_id = "account.${harness_platform_secret_text.test.id}"
+		read_only = true
+		renewal_interval_minutes = 60
+		secret_engine_manually_configured = true
+		secret_engine_name = "harness-test"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		use_vault_agent = false
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "3s"
+	}
+	`, id, name, vault_secret)
+}
+func testOrgResourceConnectorVault_app_role(id string, name string, vault_secret string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		lifecycle {
+			ignore_changes = [
+				value,
+			]
+		}
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_organization.test]
+		destroy_duration = "4s"
+	}
+	
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		app_role_id = "570acf09-ef2a-144b-2fb0-14a42e06ffe3"
+		base_path = "vikas-test/"
+		access_type = "APP_ROLE"
+		default = false
+		secret_id = "account.${harness_platform_secret_text.test.id}"
+		read_only = true
+		renewal_interval_minutes = 60
+		secret_engine_manually_configured = true
+		secret_engine_name = "harness-test"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		use_vault_agent = false
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "3s"
+	}
+	`, id, name, vault_secret)
+}
 
 func testAccResourceConnectorVault_k8s_auth(id string, name string) string {
 	return fmt.Sprintf(`
@@ -443,6 +1269,169 @@ func testAccResourceConnectorVault_k8s_auth(id string, name string) string {
 	`, id, name)
 }
 
+func testProjectResourceConnectorVault_k8s_auth(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "3s"
+	}
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "%[1]s"
+		value_type = "Reference"
+		value = "secret"
+		depends_on = [time_sleep.wait_5_seconds]
+	}
+
+	resource "time_sleep" "wait_5_seconds" {
+		depends_on = [harness_platform_connector_azure_key_vault.test]
+		create_duration = "5s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		auth_token = "${harness_platform_secret_text.test.id}"
+		base_path = "base_path"
+		access_type = "K8s_AUTH"
+		default = false
+		k8s_auth_endpoint = "k8s_auth_endpoint"
+		namespace = "namespace"
+		read_only = true
+		renewal_interval_minutes = 10
+		secret_engine_manually_configured = true
+		secret_engine_name = "secret_engine_name"
+		secret_engine_version = 2
+		service_account_token_path = "service_account_token_path"
+		use_aws_iam = false
+		use_k8s_auth = true
+		use_vault_agent = false
+		vault_k8s_auth_role = "vault_k8s_auth_role"
+		vault_aws_iam_role = "vault_aws_iam_role"
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vault_url.com"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s"
+	}
+	`, id, name)
+}
+func testOrgResourceConnectorVault_k8s_auth(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s"
+	}
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		secret_manager_identifier = "%[1]s"
+		value_type = "Reference"
+		value = "secret"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		auth_token = "org.${harness_platform_secret_text.test.id}"
+		base_path = "base_path"
+		access_type = "K8s_AUTH"
+		default = false
+		k8s_auth_endpoint = "k8s_auth_endpoint"
+		namespace = "namespace"
+		read_only = true
+		renewal_interval_minutes = 10
+		secret_engine_manually_configured = true
+		secret_engine_name = "secret_engine_name"
+		secret_engine_version = 2
+		service_account_token_path = "service_account_token_path"
+		use_aws_iam = false
+		use_k8s_auth = true
+		use_vault_agent = false
+		vault_k8s_auth_role = "vault_k8s_auth_role"
+		vault_aws_iam_role = "vault_aws_iam_role"
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vault_url.com"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s"
+	}
+	`, id, name)
+}
+
 func testAccResourceConnectorVault_vault_agent(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -489,6 +1478,166 @@ func testAccResourceConnectorVault_vault_agent(id string, name string) string {
 	`, id, name)
 }
 
+func testProjectResourceConnectorVault_vault_agent(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_project.test]
+		create_duration = "3s"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "%[1]s"
+		value_type = "Reference"
+		value = "secret"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		auth_token = "${harness_platform_secret_text.test.id}"
+		base_path = "base_path"
+		access_type = "VAULT_AGENT"
+		default = false
+		namespace = "namespace"
+		read_only = true
+		renewal_interval_minutes = 10
+		secret_engine_manually_configured = true
+		secret_engine_name = "secret_engine_name"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		use_vault_agent = true
+		sink_path = "sink_path"
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vault_url.com"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		destroy_duration = "4s"
+	}
+	`, id, name)
+}
+func testOrgResourceConnectorVault_vault_agent(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
+		secret_manager_identifier = "%[1]s"
+		value_type = "Reference"
+		value = "secret"
+		depends_on = [time_sleep.wait_2_seconds]
+	}
+
+	resource "time_sleep" "wait_2_seconds" {
+		depends_on = [harness_platform_connector_azure_key_vault.test]
+		create_duration = "2s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		auth_token = "org.${harness_platform_secret_text.test.id}"
+		base_path = "base_path"
+		access_type = "VAULT_AGENT"
+		default = false
+		namespace = "namespace"
+		read_only = true
+		renewal_interval_minutes = 10
+		secret_engine_manually_configured = true
+		secret_engine_name = "secret_engine_name"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		use_vault_agent = true
+		sink_path = "sink_path"
+		delegate_selectors = ["harness-delegate"]
+		vault_url = "https://vault_url.com"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s"
+	}
+	`, id, name)
+}
+
 func testAccResourceConnectorVault_token(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -527,6 +1676,118 @@ func testAccResourceConnectorVault_token(id string, name string) string {
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
 		destroy_duration = "4s"
+	}
+	`, id, name, helpers.TestEnvVars.VaultRootToken.Get())
+}
+func testProjectResourceConnectorVault_token(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	
+	resource "harness_platform_project" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		org_id = harness_platform_organization.test.id
+		color = "#472848"
+	}
+
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_project.test]
+		destroy_duration = "4s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
+		auth_token = "${harness_platform_secret_text.test.id}"
+		base_path = "harness"
+		access_type = "TOKEN"
+		default = false
+		read_only = true
+		renewal_interval_minutes = 0
+		secret_engine_manually_configured = true
+		secret_engine_name = "QA_Secrets"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "3s"
+	}
+	`, id, name, helpers.TestEnvVars.VaultRootToken.Get())
+}
+func testOrgResourceConnectorVault_token(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "%[3]s"
+		depends_on = [time_sleep.wait_3_seconds]
+	}
+
+	resource "time_sleep" "wait_3_seconds" {
+		depends_on = [harness_platform_organization.test]
+		create_duration = "3s"
+	}
+
+	resource "harness_platform_connector_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id= harness_platform_organization.test.id
+		auth_token = "org.${harness_platform_secret_text.test.id}"
+		base_path = "harness"
+		access_type = "TOKEN"
+		default = false
+		read_only = true
+		renewal_interval_minutes = 0
+		secret_engine_manually_configured = true
+		secret_engine_name = "QA_Secrets"
+		secret_engine_version = 2
+		use_aws_iam = false
+		use_k8s_auth = false
+		vault_url = "https://vaultqa.harness.io"
+
+		depends_on = [time_sleep.wait_4_seconds]
+	}
+
+	resource "time_sleep" "wait_4_seconds" {
+		depends_on = [harness_platform_secret_text.test]
+		create_duration = "4s"
 	}
 	`, id, name, helpers.TestEnvVars.VaultRootToken.Get())
 }

--- a/internal/service/platform/connector/vault_test.go
+++ b/internal/service/platform/connector/vault_test.go
@@ -903,7 +903,7 @@ func testAccResourceConnectorVault_aws_auth(id string, name string, vault_secret
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name, vault_secret)
 }
@@ -1005,7 +1005,7 @@ func testOrgResourceConnectorVault_aws_auth(id string, name string, vault_secret
 
 	resource "time_sleep" "wait_3_seconds" {
 		depends_on = [harness_platform_secret_organization.test]
-		destroy_duration = "3s"
+		create_duration = "3s"
 	}
 
 	resource "harness_platform_connector_vault" "test" {
@@ -1086,7 +1086,7 @@ func testAccResourceConnectorVault_app_role(id string, name string, vault_secret
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name, vault_secret)
 }
@@ -1184,7 +1184,7 @@ func testOrgResourceConnectorVault_app_role(id string, name string, vault_secret
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_organization.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	
 
@@ -1264,7 +1264,7 @@ func testAccResourceConnectorVault_k8s_auth(id string, name string) string {
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name)
 }
@@ -1473,7 +1473,7 @@ func testAccResourceConnectorVault_vault_agent(id string, name string) string {
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name)
 }
@@ -1556,7 +1556,7 @@ func testProjectResourceConnectorVault_vault_agent(id string, name string) strin
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name)
 }
@@ -1675,7 +1675,7 @@ func testAccResourceConnectorVault_token(id string, name string) string {
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 	`, id, name, helpers.TestEnvVars.VaultRootToken.Get())
 }
@@ -1708,7 +1708,7 @@ func testProjectResourceConnectorVault_token(id string, name string) string {
 
 	resource "time_sleep" "wait_4_seconds" {
 		depends_on = [harness_platform_project.test]
-		destroy_duration = "4s"
+		create_duration = "4s"
 	}
 
 	resource "harness_platform_connector_vault" "test" {

--- a/internal/service/platform/connector/vault_test.go
+++ b/internal/service/platform/connector/vault_test.go
@@ -233,6 +233,7 @@ func TestAccResourceConnectorVault_VaultAgent(t *testing.T) {
 func TestProjectResourceConnectorVault_VaultAgent(t *testing.T) {
 
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
 	name := id
 	updatedName := fmt.Sprintf("%s_updated", name)
 	resourceName := "harness_platform_connector_vault.test"
@@ -246,7 +247,7 @@ func TestProjectResourceConnectorVault_VaultAgent(t *testing.T) {
 		CheckDestroy: testAccConnectorDestroy(resourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testProjectResourceConnectorVault_vault_agent(id, name),
+				Config: testProjectResourceConnectorVault_vault_agent(id, name,connectorName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
@@ -263,7 +264,7 @@ func TestProjectResourceConnectorVault_VaultAgent(t *testing.T) {
 				),
 			},
 			{
-				Config: testProjectResourceConnectorVault_vault_agent(id, updatedName),
+				Config: testProjectResourceConnectorVault_vault_agent(id, updatedName,connectorName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
@@ -291,6 +292,7 @@ func TestProjectResourceConnectorVault_VaultAgent(t *testing.T) {
 func TestOrgResourceConnectorVault_VaultAgent(t *testing.T) {
 
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	connectorName := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(10))
 	name := id
 	updatedName := fmt.Sprintf("%s_updated", name)
 	resourceName := "harness_platform_connector_vault.test"
@@ -304,7 +306,7 @@ func TestOrgResourceConnectorVault_VaultAgent(t *testing.T) {
 		CheckDestroy: testAccConnectorDestroy(resourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testOrgResourceConnectorVault_vault_agent(id, name),
+				Config: testOrgResourceConnectorVault_vault_agent(id, name,connectorName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
@@ -321,7 +323,7 @@ func TestOrgResourceConnectorVault_VaultAgent(t *testing.T) {
 				),
 			},
 			{
-				Config: testOrgResourceConnectorVault_vault_agent(id, updatedName),
+				Config: testOrgResourceConnectorVault_vault_agent(id, updatedName,connectorName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
@@ -1478,7 +1480,7 @@ func testAccResourceConnectorVault_vault_agent(id string, name string) string {
 	`, id, name)
 }
 
-func testProjectResourceConnectorVault_vault_agent(id string, name string) string {
+func testProjectResourceConnectorVault_vault_agent(id string, name string,connectorName string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_organization" "test" {
 		identifier = "%[1]s"
@@ -1493,7 +1495,7 @@ func testProjectResourceConnectorVault_vault_agent(id string, name string) strin
 	}
 
 	resource "harness_platform_connector_azure_key_vault" "test" {
-		identifier = "%[1]s"
+		identifier = "%[3]s"
 		name = "%[2]s"
 		description = "test"
 		tags = ["foo:bar"]
@@ -1522,9 +1524,15 @@ func testProjectResourceConnectorVault_vault_agent(id string, name string) strin
 		tags = ["foo:bar"]
 		org_id= harness_platform_organization.test.id
 		project_id=harness_platform_project.test.id
-		secret_manager_identifier = "%[1]s"
+		secret_manager_identifier = "%[3]s"
 		value_type = "Reference"
 		value = "secret"
+		depends_on = [time_sleep.wait_5_seconds]
+	}
+
+	resource "time_sleep" "wait_5_seconds" {
+		depends_on = [harness_platform_connector_azure_key_vault.test]
+		create_duration = "5s"
 	}
 
 	resource "harness_platform_connector_vault" "test" {
@@ -1558,16 +1566,16 @@ func testProjectResourceConnectorVault_vault_agent(id string, name string) strin
 		depends_on = [harness_platform_secret_text.test]
 		create_duration = "4s"
 	}
-	`, id, name)
+	`, id, name,connectorName)
 }
-func testOrgResourceConnectorVault_vault_agent(id string, name string) string {
+func testOrgResourceConnectorVault_vault_agent(id string, name string,connectorName string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_organization" "test" {
 		identifier = "%[1]s"
 		name = "%[2]s"
 	}
 	resource "harness_platform_connector_azure_key_vault" "test" {
-		identifier = "%[1]s"
+		identifier = "%[3]s"
 		name = "%[2]s"
 		description = "test"
 		tags = ["foo:bar"]
@@ -1594,7 +1602,7 @@ func testOrgResourceConnectorVault_vault_agent(id string, name string) string {
 		description = "test"
 		tags = ["foo:bar"]
 		org_id = harness_platform_organization.test.id
-		secret_manager_identifier = "%[1]s"
+		secret_manager_identifier = "%[3]s"
 		value_type = "Reference"
 		value = "secret"
 		depends_on = [time_sleep.wait_2_seconds]
@@ -1635,7 +1643,7 @@ func testOrgResourceConnectorVault_vault_agent(id string, name string) string {
 		depends_on = [harness_platform_secret_text.test]
 		create_duration = "4s"
 	}
-	`, id, name)
+	`, id, name,connectorName)
 }
 
 func testAccResourceConnectorVault_token(id string, name string) string {

--- a/internal/service/platform/resource_group/resource_group_test.go
+++ b/internal/service/platform/resource_group/resource_group_test.go
@@ -56,6 +56,92 @@ func TestAccResourceResourceGroup(t *testing.T) {
 
 }
 
+func TestProjectResourceResourceGroup(t *testing.T) {
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_resource_group.test"
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccResourceGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceResourceGroup(id, name, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testProjectResourceResourceGroup(id, updatedName, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+
+}
+
+func TestOrgResourceResourceGroup(t *testing.T) {
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_resource_group.test"
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccResourceGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceResourceGroup(id, name, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testOrgResourceResourceGroup(id, updatedName, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+
+}
+
 func TestAccResourceResourceGroup_emptyAttributeFilter(t *testing.T) {
 	name := t.Name()
 	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
@@ -92,7 +178,92 @@ func TestAccResourceResourceGroup_emptyAttributeFilter(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				
+			},
+		},
+	})
+
+}
+
+func TestProjectResourceResourceGroup_emptyAttributeFilter(t *testing.T) {
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_resource_group.test"
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccResourceGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceResourceGroupEmptyAttributeFilter(id, name, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testProjectResourceResourceGroupEmptyAttributeFilter(id, updatedName, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+
+}
+func TestOrgResourceResourceGroup_emptyAttributeFilter(t *testing.T) {
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_resource_group.test"
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccResourceGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceResourceGroupEmptyAttributeFilter(id, name, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				Config: testOrgResourceResourceGroupEmptyAttributeFilter(id, updatedName, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", accountId),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -139,6 +310,34 @@ func buildField(r *terraform.ResourceState, field string) optional.String {
 
 func testAccResourceResourceGroup(id string, name string, accountId string) string {
 	return fmt.Sprintf(`
+		resource "harness_platform_resource_group" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			account_id = "%[3]s"
+			allowed_scope_levels =["account"]
+			included_scopes {
+				filter = "EXCLUDING_CHILD_SCOPES"
+				account_id = "%[3]s"
+				
+			}
+			resource_filter {
+				include_all_resources = false
+				resources {
+					resource_type = "CONNECTOR"
+					attribute_filter {
+						attribute_name = "category"
+						attribute_values = ["value"]
+					}
+				}
+			}
+		}
+	`, id, name, accountId)
+}
+func testProjectResourceResourceGroup(id string, name string, accountId string) string {
+	return fmt.Sprintf(`
 	resource "harness_platform_organization" "test" {
 		identifier = "%[1]s"
 		name = "%[2]s"
@@ -181,7 +380,66 @@ func testAccResourceResourceGroup(id string, name string, accountId string) stri
 	`, id, name, accountId)
 }
 
+func testOrgResourceResourceGroup(id string, name string, accountId string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+		}
+		resource "harness_platform_resource_group" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			account_id = "%[3]s"
+			org_id = harness_platform_organization.test.id
+			
+			allowed_scope_levels =["organization"]
+			included_scopes {
+				filter = "EXCLUDING_CHILD_SCOPES"
+				account_id = "%[3]s"
+				org_id = harness_platform_organization.test.id
+				
+			}
+			resource_filter {
+				include_all_resources = false
+				resources {
+					resource_type = "CONNECTOR"
+					attribute_filter {
+						attribute_name = "category"
+						attribute_values = ["value"]
+					}
+				}
+			}
+		}
+	`, id, name, accountId)
+}
+
 func testAccResourceResourceGroupEmptyAttributeFilter(id string, name string, accountId string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_resource_group" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			account_id = "%[3]s"
+			allowed_scope_levels =["account"]
+			included_scopes {
+				filter = "EXCLUDING_CHILD_SCOPES"
+				account_id = "%[3]s"
+			}
+			resource_filter {
+				include_all_resources = false
+				resources {
+					resource_type = "CONNECTOR"
+				}
+			}
+		}
+	`, id, name, accountId)
+}
+func testProjectResourceResourceGroupEmptyAttributeFilter(id string, name string, accountId string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_organization" "test" {
 		identifier = "%[1]s"
@@ -210,6 +468,37 @@ func testAccResourceResourceGroupEmptyAttributeFilter(id string, name string, ac
 				account_id = "%[3]s"
 				org_id = harness_platform_project.test.org_id
 				project_id = harness_platform_project.test.id
+			}
+			resource_filter {
+				include_all_resources = false
+				resources {
+					resource_type = "CONNECTOR"
+				}
+			}
+		}
+	`, id, name, accountId)
+}
+
+func testOrgResourceResourceGroupEmptyAttributeFilter(id string, name string, accountId string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+		}
+	
+		resource "harness_platform_resource_group" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			account_id = "%[3]s"
+			org_id = harness_platform_organization.test.identifier
+			allowed_scope_levels =["organization"]
+			included_scopes {
+				filter = "EXCLUDING_CHILD_SCOPES"
+				account_id = "%[3]s"
+				org_id = harness_platform_organization.test.identifier
 			}
 			resource_filter {
 				include_all_resources = false

--- a/internal/service/platform/roles/resource_roles_test.go
+++ b/internal/service/platform/roles/resource_roles_test.go
@@ -33,11 +33,57 @@ func TestAccResourceRoles(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", "core_pipeline_edit"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "project"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "account"),
 				),
 			},
 			{
 				Config: testAccResourceRoles(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "core_pipeline_edit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "account"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"org_id", "project_id"},
+			},
+		},
+	})
+
+}
+
+func TestProjectResourceRoles(t *testing.T) {
+
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+
+	resourceName := "harness_platform_roles.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccRolesDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceRoles(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "core_pipeline_edit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "project"),
+				),
+			},
+			{
+				Config: testProjectResourceRoles(id, updatedName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
@@ -52,6 +98,54 @@ func TestAccResourceRoles(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: acctest.ProjectResourceImportStateIdFunc(resourceName),
+				
+			},
+		},
+	})
+
+}
+
+func TestOrgResourceRoles(t *testing.T) {
+
+	name := t.Name()
+	id := fmt.Sprintf("%s_%s", name, utils.RandStringBytes(5))
+	updatedName := fmt.Sprintf("%s_updated", name)
+
+	resourceName := "harness_platform_roles.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccRolesDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceRoles(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "core_pipeline_edit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "organization"),
+				),
+			},
+			{
+				Config: testOrgResourceRoles(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "core_pipeline_edit"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_scope_levels.0", "organization"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.OrgResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"project_id"},
 			},
 		},
 	})
@@ -95,27 +189,62 @@ func buildField(r *terraform.ResourceState, field string) optional.String {
 
 func testAccResourceRoles(id string, name string) string {
 	return fmt.Sprintf(`
+	resource "harness_platform_roles" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		permissions = ["core_pipeline_edit"]
+		allowed_scope_levels = ["account"]
+	}
+`, id, name)
+}
+
+func testProjectResourceRoles(id string, name string) string {
+	return fmt.Sprintf(`
 	resource "harness_platform_organization" "test" {
 		identifier = "%[1]s"
 		name = "%[2]s"
 	}
 
 	resource "harness_platform_project" "test" {
-		identifier = "%[1]s"
-		name = "%[2]s"
-		color = "#0063F7"
-		org_id = harness_platform_organization.test.identifier
+    identifier = "%[1]s"
+    name = "%[2]s"
+    org_id = harness_platform_organization.test.id
+    color = "#472848"
 	}
 
 	resource "harness_platform_roles" "test" {
-		org_id = harness_platform_project.test.org_id
-		project_id = harness_platform_project.test.id
+		org_id = harness_platform_organization.test.id
+		project_id=harness_platform_project.test.id
 		identifier = "%[1]s"
 		name = "%[2]s"
 		description = "test"
 		tags = ["foo:bar"]
 		permissions = ["core_pipeline_edit"]
 		allowed_scope_levels = ["project"]
+	}
+`, id, name)
+}
+
+func testOrgResourceRoles(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_organization" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+	}
+
+	
+
+	resource "harness_platform_roles" "test" {
+		org_id = harness_platform_organization.test.id
+		
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		permissions = ["core_pipeline_edit"]
+		allowed_scope_levels = ["organization"]
 	}
 `, id, name)
 }

--- a/internal/service/platform/secret/text_test.go
+++ b/internal/service/platform/secret/text_test.go
@@ -109,6 +109,165 @@ func TestAccResourceSecretText_reference(t *testing.T) {
 		},
 	})
 }
+func TestProjectSecretText_inline(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	secretValue := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	updatedValue := secretValue + "updated"
+	resourceName := "harness_platform_secret_text.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccSecretDestroy(resourceName),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceSecretText_inline(id, name, secretValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", "harnessSecretManager"),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Inline"),
+					resource.TestCheckResourceAttr(resourceName, "value", secretValue),
+				),
+			},
+			{
+				Config: testProjectResourceSecretText_inline(id, updatedName, updatedValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", "harnessSecretManager"),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Inline"),
+					resource.TestCheckResourceAttr(resourceName, "value", updatedValue),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"value"},
+			},
+		},
+	})
+}
+
+func TestOrgSecretText_inline(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	secretValue := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	updatedValue := secretValue + "updated"
+	resourceName := "harness_platform_secret_text.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccSecretDestroy(resourceName),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceSecretText_inline(id, name, secretValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", "harnessSecretManager"),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Inline"),
+				),
+			},
+			{
+				Config: testOrgResourceSecretText_inline(id, updatedName, updatedValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", "harnessSecretManager"),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Inline"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.OrgResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"value"},
+			},
+		},
+	})
+}
+
+func TestOrgResourceSecretText_reference(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	secretValue := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	updatedValue := secretValue + "updated"
+	resourceName := "harness_platform_secret_text.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccSecretDestroy(resourceName),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceSecretText_reference(id, name, secretValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Reference"),
+					resource.TestCheckResourceAttr(resourceName, "value", secretValue),
+				),
+			},
+			{
+				Config: testOrgResourceSecretText_reference(id, updatedName, updatedValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secret_manager_identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "Reference"),
+					resource.TestCheckResourceAttr(resourceName, "value", updatedValue),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.OrgResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"value"},
+			},
+		},
+	})
+}
 
 func TestAccSecretText_DeleteUnderLyingResource(t *testing.T) {
 	name := t.Name()
@@ -168,6 +327,115 @@ func testAccResourceSecret_text_reference(id string, name string, secretValue st
 			secret_manager_identifier = "azureSecretManager"
 			value_type = "Reference"
 			value = "%[3]s"
+		}
+`, id, name, secretValue)
+}
+
+func testProjectResourceSecretText_inline(id string, name string, secretValue string) string {
+	return fmt.Sprintf(`
+  resource "harness_platform_organization" "test" {
+    identifier = "%[1]s"
+    name = "%[2]s"
+  }
+  resource "harness_platform_project" "test" {
+    identifier = "%[1]s"
+    name = "%[2]s"
+    org_id = harness_platform_organization.test.id
+    color = "#472848"
+	}
+	
+    resource "harness_platform_secret_text" "test" {
+      identifier = "%[1]s"
+      name = "%[2]s"
+      description = "test"
+      tags = ["foo:bar"]
+      secret_manager_identifier = "harnessSecretManager"
+      value_type = "Inline"
+      value = "%[3]s"
+      org_id = harness_platform_organization.test.id
+      project_id = harness_platform_project.test.id
+    	depends_on = [time_sleep.wait_3_seconds]
+	}
+	resource "time_sleep" "wait_3_seconds" {
+		create_duration = "3s"
+		depends_on = [harness_platform_project.test]
+		
+	}
+`, id, name, secretValue)
+}
+
+func testOrgResourceSecretText_inline(id string, name string, secretValue string) string {
+	return fmt.Sprintf(`
+  resource "harness_platform_organization" "test" {
+    identifier = "%[1]s"
+    name = "%[2]s"
+  }
+  
+    resource "harness_platform_secret_text" "test" {
+      identifier = "%[1]s"
+      name = "%[2]s"
+      description = "test"
+      tags = ["foo:bar"]
+      secret_manager_identifier = "harnessSecretManager"
+      value_type = "Inline"
+      value = "%[3]s"
+      org_id = harness_platform_organization.test.id
+      depends_on = [time_sleep.wait_4_seconds]
+    }
+    resource "time_sleep" "wait_4_seconds" {
+			create_duration = "3s"
+			depends_on = [harness_platform_organization.test]
+			
+		}
+`, id, name, secretValue)
+}
+
+func testOrgResourceSecretText_reference(id string, name string, secretValue string) string {
+	return fmt.Sprintf(`
+  resource "harness_platform_organization" "test" {
+    identifier = "%[1]s"
+    name = "%[2]s"
+  }
+
+	resource "harness_platform_connector_azure_key_vault" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+		org_id = harness_platform_organization.test.id
+
+		client_id = "38fca8d7-4dda-41d5-b106-e5d8712b733a"
+		secret_key = "account.azuretest"
+		tenant_id = "b229b2bb-5f33-4d22-bce0-730f6474e906"
+		vault_name = "Aman-test"
+		subscription = "20d6a917-99fa-4b1b-9b2e-a3d624e9dcf0"
+		is_default = false
+
+		azure_environment_type = "AZURE"
+	  depends_on = [time_sleep.wait_3_seconds]
+    }
+    resource "time_sleep" "wait_3_seconds" {
+			create_duration = "3s"
+			depends_on = [harness_platform_organization.test]
+			
+		}
+
+    resource "harness_platform_secret_text" "test" {
+      identifier = "%[1]s"
+      name = "%[2]s"
+      description = "test"
+      tags = ["foo:bar"]
+
+      secret_manager_identifier = "%[1]s"
+      value_type = "Reference"
+      value = "%[3]s"
+      org_id = harness_platform_organization.test.id
+      depends_on = [time_sleep.wait_4_seconds]
+    }
+    resource "time_sleep" "wait_4_seconds" {
+			create_duration = "3s"
+			depends_on = [harness_platform_connector_azure_key_vault.test]
+			
 		}
 `, id, name, secretValue)
 }

--- a/internal/service/platform/service/resource_service_test.go
+++ b/internal/service/platform/service/resource_service_test.go
@@ -30,7 +30,6 @@ func TestAccResourceService(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					
 				),
 			},
 			{
@@ -38,7 +37,6 @@ func TestAccResourceService(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
-					
 				),
 			},
 			{
@@ -109,7 +107,6 @@ func TestOrgResourceService(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
-					
 				),
 			},
 			{
@@ -118,7 +115,6 @@ func TestOrgResourceService(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
-					
 				),
 			},
 			{
@@ -261,7 +257,7 @@ func TestAccResourceService_DeleteUnderlyingResource(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceService(id, name),
+				Config: testProjectResourceService(id, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -277,7 +273,7 @@ func TestAccResourceService_DeleteUnderlyingResource(t *testing.T) {
 					})
 					require.NoError(t, err)
 				},
-				Config:             testAccResourceService(id, name),
+				Config:             testProjectResourceService(id, name),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
@@ -342,7 +338,6 @@ func testAccResourceServiceWithoutServiceDefinition(id string, name string) stri
 `, id, name)
 }
 
-
 func testProjectResourceService(id string, name string) string {
 	return fmt.Sprintf(`
     resource "harness_platform_organization" "test" {
@@ -392,7 +387,6 @@ func testProjectResourceServiceWithoutServiceDefinition(id string, name string) 
     }
 `, id, name)
 }
-
 
 func testOrgResourceService(id string, name string) string {
 	return fmt.Sprintf(`

--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -259,7 +259,7 @@ func TestAccResourceUserGroup_DeleteUnderlyingResource(t *testing.T) {
 		ProviderFactories: acctest.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceUserGroup(id, name),
+				Config: testProjectResourceUserGroup(id, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/antihax/optional"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
-	"github.com/harness/terraform-provider-harness/internal"
 	"github.com/harness/harness-go-sdk/harness/utils"
+	"github.com/harness/terraform-provider-harness/internal"
 	"github.com/harness/terraform-provider-harness/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
-
 )
 
 func TestAccResourceUserGroup(t *testing.T) {
@@ -46,6 +45,80 @@ func TestAccResourceUserGroup(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"users"},
+			},
+		},
+	})
+}
+
+func TestProjectResourceUserGroup(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_usergroup.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccUserGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceUserGroup(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testProjectResourceUserGroup(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"users"},
+			},
+		},
+	})
+}
+
+func TestOrgResourceUserGroup(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_usergroup.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccUserGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceUserGroup(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testOrgResourceUserGroup(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.OrgResourceImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{"users"},
 			},
 		},
@@ -93,6 +166,88 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 	})
 }
 
+func TestProjectResourceUserGroup_emails(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_usergroup.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccUserGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectResourceUserGroup_emails(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+				),
+			},
+			{
+				Config: testProjectResourceUserGroup_emails(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"user_emails"},
+			},
+		},
+	})
+}
+
+func TestOrgResourceUserGroup_emails(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_usergroup.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccUserGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrgResourceUserGroup_emails(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+				),
+			},
+			{
+				Config: testOrgResourceUserGroup_emails(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.OrgResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"user_emails"},
+			},
+		},
+	})
+}
+
 func TestAccResourceUserGroup_DeleteUnderlyingResource(t *testing.T) {
 
 	name := t.Name()
@@ -109,7 +264,6 @@ func TestAccResourceUserGroup_DeleteUnderlyingResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 				),
-
 			},
 			{
 				PreConfig: func() {
@@ -120,7 +274,7 @@ func TestAccResourceUserGroup_DeleteUnderlyingResource(t *testing.T) {
 						ProjectIdentifier: optional.NewString(id),
 					})
 					require.NoError(t, err)
-				
+
 				},
 				Config:             testAccResourceUserGroup(id, name),
 				PlanOnly:           true,
@@ -165,6 +319,40 @@ func testAccUserGroupDestroy(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccResourceUserGroup(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_usergroup" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			linked_sso_id = "linked_sso_id"
+			externally_managed = false
+			users = []
+			notification_configs {
+				type = "SLACK"
+				slack_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "EMAIL"
+				group_email = "email@email.com"
+				send_email_to_all_users = true
+			}
+			notification_configs {
+				type = "MSTEAMS"
+				microsoft_teams_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "PAGERDUTY"
+				pager_duty_key = "pagerDutyKey"
+			}
+			linked_sso_display_name = "linked_sso_display_name"
+			sso_group_id = "sso_group_id"
+			sso_group_name = "sso_group_name"
+			linked_sso_type = "SAML"
+			sso_linked = true
+		}
+`, id, name)
+}
+
+func testProjectResourceUserGroup(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_organization" "test" {
 			identifier = "%[1]s"
@@ -212,7 +400,81 @@ func testAccResourceUserGroup(id string, name string) string {
 `, id, name)
 }
 
+func testOrgResourceUserGroup(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+		}
+
+		resource "harness_platform_usergroup" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			org_id = harness_platform_organization.test.id
+			linked_sso_id = "linked_sso_id"
+			externally_managed = false
+			users = []
+			notification_configs {
+				type = "SLACK"
+				slack_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "EMAIL"
+				group_email = "email@email.com"
+				send_email_to_all_users = true
+			}
+			notification_configs {
+				type = "MSTEAMS"
+				microsoft_teams_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "PAGERDUTY"
+				pager_duty_key = "pagerDutyKey"
+			}
+			linked_sso_display_name = "linked_sso_display_name"
+			sso_group_id = "sso_group_id"
+			sso_group_name = "sso_group_name"
+			linked_sso_type = "SAML"
+			sso_linked = true
+		}
+`, id, name)
+}
+
 func testAccResourceUserGroup_emails(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_usergroup" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			linked_sso_id = "linked_sso_id"
+			externally_managed = false
+			user_emails = ["rathod.meetsatish@harness.io"]
+			notification_configs {
+				type = "SLACK"
+				slack_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "EMAIL"
+				group_email = "email@email.com"
+				send_email_to_all_users = true
+			}
+			notification_configs {
+				type = "MSTEAMS"
+				microsoft_teams_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "PAGERDUTY"
+				pager_duty_key = "pagerDutyKey"
+			}
+			linked_sso_display_name = "linked_sso_display_name"
+			sso_group_id = "sso_group_id"
+			sso_group_name = "sso_group_name"
+			linked_sso_type = "SAML"
+			sso_linked = true
+		}
+`, id, name)
+}
+
+func testProjectResourceUserGroup_emails(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_organization" "test" {
 			identifier = "%[1]s"
@@ -231,6 +493,46 @@ func testAccResourceUserGroup_emails(id string, name string) string {
 			name = "%[2]s"
 			org_id = harness_platform_project.test.org_id
 			project_id = harness_platform_project.test.id
+			linked_sso_id = "linked_sso_id"
+			externally_managed = false
+			user_emails = ["rathod.meetsatish@harness.io"]
+			notification_configs {
+				type = "SLACK"
+				slack_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "EMAIL"
+				group_email = "email@email.com"
+				send_email_to_all_users = true
+			}
+			notification_configs {
+				type = "MSTEAMS"
+				microsoft_teams_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "PAGERDUTY"
+				pager_duty_key = "pagerDutyKey"
+			}
+			linked_sso_display_name = "linked_sso_display_name"
+			sso_group_id = "sso_group_id"
+			sso_group_name = "sso_group_name"
+			linked_sso_type = "SAML"
+			sso_linked = true
+		}
+`, id, name)
+}
+
+func testOrgResourceUserGroup_emails(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+		}
+
+		resource "harness_platform_usergroup" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			org_id = harness_platform_organization.test.id
 			linked_sso_id = "linked_sso_id"
 			externally_managed = false
 			user_emails = ["rathod.meetsatish@harness.io"]


### PR DESCRIPTION
## Describe your changes
1. Added Coverage For Organization & Project Level For Secret Text
2. Added Coverage For Organization & Project Level For Variables
3. Added Coverage For Organization & Project Level For Roles 
4. Added Coverage For Organization & Project Level For Service
5. Added Coverage For Organization & Project Level For Resource Group
6. Added Coverage For Organization & Project Level For AWS KMS
7. Added Coverage For Organization & Project Level For Vault
8. Added Coverage For Organization & Project Level For Pager Duty
9. Added Coverage For Organization & Project Level For GCP SM
10. Added Coverage For Organization & Project Level For Azure Key Vault
11. Added Coverage For Organization & Project Level For AWS SM
12. Added Coverage For Organization & Project Level For User Group


## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
