### PR TITLE
Added TCs for Data Sources in Variable

### DIFF
--- a/internal/service/platform/variables/data_source_variables_test.go
+++ b/internal/service/platform/variables/data_source_variables_test.go
@@ -23,6 +23,27 @@ func TestAccDataSourceVariables(t *testing.T) {
 				Config: testAccDataSourceVariables(id, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func TestProjectDataSourceVariables(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(6))
+	name := id
+	resourceName := "data.harness_platform_variables.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testProjectDataSourceVariables(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "project_id", id),
@@ -55,6 +76,24 @@ func TestAccDataSourceVariablesOrgLevel(t *testing.T) {
 }
 
 func testAccDataSourceVariables(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_variables" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			type = "String"
+			spec {
+				value_type = "FIXED"
+				fixed_value = "%[2]s"
+			}
+		}
+
+		data "harness_platform_variables" "test" {
+			identifier = harness_platform_variables.test.identifier
+		}
+`, id, name)
+}
+
+func testProjectDataSourceVariables(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_organization" "test" {
 			identifier = "%[1]s"


### PR DESCRIPTION
## Describe your changes
Added TCs For Data Source Variable

<img width="1651" alt="Screenshot 2023-03-29 at 11 28 40 AM" src="https://user-images.githubusercontent.com/122971747/228440047-70a43ac5-1d20-4ba
<img width="1592" alt="Screenshot 2023-03-29 at 11 28 55 AM" src="https://user-images.githubusercontent.com/122971747/228440088-e1d214a4-6bbc-4977-870e-560521729aba.png">
8-8f12-81d8416a2c8b.png">
<img width="1646" alt="Screenshot 2023-03-29 at 11 29 13 AM" src="https://user-images.githubusercontent.com/122971747/228440131-c67d4777-d6eb-40ff-a3cf-fcd1e5fffa74.png">

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
