### PR TITLE
PL-38654 Secret File Not Getting Created with Tags separated by comma

### DIFF
--- a/internal/service/platform/secret/file.go
+++ b/internal/service/platform/secret/file.go
@@ -121,18 +121,30 @@ func buildSpec(d *schema.ResourceData) string {
 
 func buildTag(no_of_tags int, tags *schema.Set) string {
 	result := "{"
+	tagMap := make(map[string]string)
 	for i := 0; i < tags.Len(); i++ {
 		tag := fmt.Sprintf("%v", tags.List()[i])
-		split_tag := strings.Split(tag, ":")
-		key := split_tag[0]
-		value := split_tag[1]
-		if i == tags.Len()-1 {
-			result = result + fmt.Sprintf(`"%[1]s":"%[2]s"`, key, value)
+		splitTag := strings.Split(tag, ",")
+		key := splitTag[0]
+		if len(splitTag) > 1 {
+			value := splitTag[1]
+			tagMap[key] = value
 		} else {
-			result = result + fmt.Sprintf(`"%[1]s":"%[2]s,",`, key, value)
+			tagMap[key] = ""
 		}
 	}
-	result = result + "}"
+
+	first := true
+	for key, value := range tagMap {
+		if !first {
+			result += ","
+		} else {
+			first = false
+		}
+		result += fmt.Sprintf(`"%[1]s":"%[2]s"`, key, value)
+	}
+
+	result += "}"
 	return result
 }
 


### PR DESCRIPTION
## Describe your changes
We had an issue with secret file creation if tags were separated by comma , it would result in crashing of the plugin . 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
