### PR TITLE
fix: [PL-38768]: Ignore order of userEmails when userGroup is created/updated via terraform

### DIFF
--- a/.changelog/567.txt
+++ b/.changelog/567.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/harness_platform_usergroup - ignore the order of users and user_emails when doing CRUD.
+```

--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -178,7 +178,6 @@ func TestAccResourceUserGroup_userIds(t *testing.T) {
 	name := id
 	updatedName := fmt.Sprintf("%s_updated", name)
 	resourceName := "harness_platform_usergroup.test"
-	// users = ["FZ-_NefESDmVvjrhu53MWQ", "TRqwkV-jSvyPdW-4C1c3eg", "0qBvYLghQqCnY9RrmuLJdg", "4PuRra9dTOCbT7RnG3-PRw"]
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.TestAccPreCheck(t) },

--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -142,7 +142,7 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
 				),
 			},
@@ -151,7 +151,7 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
-					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
 				),
 			},
@@ -447,7 +447,7 @@ func testAccResourceUserGroup_emails(id string, name string) string {
 			name = "%[2]s"
 			linked_sso_id = "linked_sso_id"
 			externally_managed = false
-			user_emails = ["rathod.meetsatish@harness.io"]
+			user_emails = ["rathod.meetsatish@harness.io", "vikas.maddukuri@harness.io", "arkajyoti.mukherjee@harness.io", "mankrit.singh@harness.io"]
 			notification_configs {
 				type = "SLACK"
 				slack_webhook_url = "https://google.com"

--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -144,6 +144,9 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.1", "vikas.maddukuri@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.2", "arkajyoti.mukherjee@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.3", "mankrit.singh@harness.io"),
 				),
 			},
 			{
@@ -153,6 +156,9 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "user_emails.0", "rathod.meetsatish@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.1", "vikas.maddukuri@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.2", "arkajyoti.mukherjee@harness.io"),
+					resource.TestCheckResourceAttr(resourceName, "user_emails.3", "mankrit.singh@harness.io"),
 				),
 			},
 			{
@@ -161,6 +167,54 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
 				ImportStateVerifyIgnore: []string{"user_emails"},
+			},
+		},
+	})
+}
+
+func TestAccResourceUserGroup_userIds(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_usergroup.test"
+	// users = ["FZ-_NefESDmVvjrhu53MWQ", "TRqwkV-jSvyPdW-4C1c3eg", "0qBvYLghQqCnY9RrmuLJdg", "4PuRra9dTOCbT7RnG3-PRw"]
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccUserGroupDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceUserGroup_userIds(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "users.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "users.0", "FZ-_NefESDmVvjrhu53MWQ"),
+					resource.TestCheckResourceAttr(resourceName, "users.1", "TRqwkV-jSvyPdW-4C1c3eg"),
+					resource.TestCheckResourceAttr(resourceName, "users.2", "0qBvYLghQqCnY9RrmuLJdg"),
+					resource.TestCheckResourceAttr(resourceName, "users.3", "4PuRra9dTOCbT7RnG3-PRw"),
+				),
+			},
+			{
+				Config: testAccResourceUserGroup_userIds(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "users.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "users.0", "FZ-_NefESDmVvjrhu53MWQ"),
+					resource.TestCheckResourceAttr(resourceName, "users.1", "TRqwkV-jSvyPdW-4C1c3eg"),
+					resource.TestCheckResourceAttr(resourceName, "users.2", "0qBvYLghQqCnY9RrmuLJdg"),
+					resource.TestCheckResourceAttr(resourceName, "users.3", "4PuRra9dTOCbT7RnG3-PRw"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"users"},
 			},
 		},
 	})
@@ -448,6 +502,40 @@ func testAccResourceUserGroup_emails(id string, name string) string {
 			linked_sso_id = "linked_sso_id"
 			externally_managed = false
 			user_emails = ["rathod.meetsatish@harness.io", "vikas.maddukuri@harness.io", "arkajyoti.mukherjee@harness.io", "mankrit.singh@harness.io"]
+			notification_configs {
+				type = "SLACK"
+				slack_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "EMAIL"
+				group_email = "email@email.com"
+				send_email_to_all_users = true
+			}
+			notification_configs {
+				type = "MSTEAMS"
+				microsoft_teams_webhook_url = "https://google.com"
+			}
+			notification_configs {
+				type = "PAGERDUTY"
+				pager_duty_key = "pagerDutyKey"
+			}
+			linked_sso_display_name = "linked_sso_display_name"
+			sso_group_id = "sso_group_id"
+			sso_group_name = "sso_group_name"
+			linked_sso_type = "SAML"
+			sso_linked = true
+		}
+`, id, name)
+}
+
+func testAccResourceUserGroup_userIds(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_usergroup" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			linked_sso_id = "linked_sso_id"
+			externally_managed = false
+			users = ["FZ-_NefESDmVvjrhu53MWQ", "TRqwkV-jSvyPdW-4C1c3eg", "0qBvYLghQqCnY9RrmuLJdg", "4PuRra9dTOCbT7RnG3-PRw"]
 			notification_configs {
 				type = "SLACK"
 				slack_webhook_url = "https://google.com"


### PR DESCRIPTION
## Describe your changes
UserGroup CRUD is showing up tfstate is different than the current terraform configuration when applying terraform plan after applying. This is because, the list of users and user_emails is different from the received and the input (in terms of ordering).
This PR handles ignoring of this order
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
