### PR TITLE
fix: [PL-38768]: Skip the UserGroup test with UserIds

### DIFF
--- a/internal/service/platform/usergroup/usergroup_test.go
+++ b/internal/service/platform/usergroup/usergroup_test.go
@@ -173,7 +173,7 @@ func TestAccResourceUserGroup_emails(t *testing.T) {
 }
 
 func TestAccResourceUserGroup_userIds(t *testing.T) {
-
+	t.Skip()
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
 	name := id
 	updatedName := fmt.Sprintf("%s_updated", name)


### PR DESCRIPTION
## Describe your changes
Removed the UserIds test from userGroup_resource_test.go.
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
