### PR TITLE
ER: [PL-39021]: Updated the documentation for Resource Group

### DIFF
--- a/docs/resources/platform_resource_group.md
+++ b/docs/resources/platform_resource_group.md
@@ -31,7 +31,7 @@ resource "harness_platform_resource_group" "test" {
       resource_type = "CONNECTOR"
       attribute_filter {
         attribute_name   = "category"
-        attribute_values = ["value"]
+        attribute_values = ["CLOUD_COST"]
       }
     }
   }
@@ -101,8 +101,8 @@ Optional:
 
 Optional:
 
-- `attribute_name` (String) Name of the attribute
-- `attribute_values` (Set of String) Value of the attributes
+- `attribute_name` (String) Name of the attribute. Valid values are `category` or `type`.
+- `attribute_values` (Set of String) Value of the attributes.Valid values for `category` are [ARTIFACTORY,CLOUD_COST,CLOUD_PROVIDER,CODE_REPO,MONITORING,SECRET_MANAGER,TICKETING] and for `type` are [Production,PreProduction]
 
 ## Import
 

--- a/examples/resources/harness_platform_resource_group/resource.tf
+++ b/examples/resources/harness_platform_resource_group/resource.tf
@@ -16,7 +16,7 @@ resource "harness_platform_resource_group" "test" {
       resource_type = "CONNECTOR"
       attribute_filter {
         attribute_name   = "category"
-        attribute_values = ["value"]
+        attribute_values = ["CLOUD_COST"]
       }
     }
   }

--- a/internal/service/platform/resource_group/resource_group.go
+++ b/internal/service/platform/resource_group/resource_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harness/terraform-provider-harness/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceResourceGroup() *schema.Resource {
@@ -107,12 +108,13 @@ func ResourceResourceGroup() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"attribute_name": {
-													Description: "Name of the attribute",
-													Type:        schema.TypeString,
-													Optional:    true,
+													Description:  "Name of the attribute. Valid values are `category` or `type`.",
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice([]string{"category", "type"}, false),
 												},
 												"attribute_values": {
-													Description: "Value of the attributes",
+													Description: "Value of the attributes.Valid values for `category` are [ARTIFACTORY,CLOUD_COST,CLOUD_PROVIDER,CODE_REPO,MONITORING,SECRET_MANAGER,TICKETING] and for `type` are [Production,PreProduction]",
 													Type:        schema.TypeSet,
 													Optional:    true,
 													Elem: &schema.Schema{


### PR DESCRIPTION
## Describe your changes
We have added more clarity to our documentation for resource group that adds what values we support in **attribute_name** and **attribute_values** field .

Updated the example as well .

This is how it looks now

<img width="1116" alt="Screenshot 2023-06-14 at 2 42 29 AM" src="https://github.com/harness/terraform-provider-harness/assets/122971747/d918ee70-4ecf-4615-a69b-9dc83dcf5233">



## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
