### PR TITLE
fix: [PL-39958]: Modified apiToken dataSource docs to include accountId

### DIFF
--- a/.changelog/618.txt
+++ b/.changelog/618.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ Fix dataSourceTokenRead documentation.
+```

--- a/examples/data-sources/harness_platform_token/data-source.tf
+++ b/examples/data-sources/harness_platform_token/data-source.tf
@@ -1,6 +1,7 @@
 data "harness_platform_token" "test" {
   identifier  = "test_token"
   parent_id   = "apikey_parent_id"
+  account_id  = "account_id"
   org_id      = "org_id"
   project_id  = "project_id"
   apikey_id   = "apikey_id"

--- a/internal/service/platform/api_key/data_source_apiKey.go
+++ b/internal/service/platform/api_key/data_source_apiKey.go
@@ -94,10 +94,10 @@ func dataSourceApiKeyRead(ctx context.Context, d *schema.ResourceData, meta inte
 			OrgIdentifier:     helpers.BuildField(d, "org_id"),
 			ProjectIdentifier: helpers.BuildField(d, "project_id"),
 		})
-		apiKey = resp.Data.ApiKey
 		if err != nil {
 			return helpers.HandleApiError(err, d, httpResp)
 		}
+		apiKey := resp.Data.ApiKey
 
 		if apiKey == nil {
 			d.SetId("")

--- a/internal/service/platform/token/data_source_token.go
+++ b/internal/service/platform/token/data_source_token.go
@@ -132,10 +132,10 @@ func dataSourceTokenRead(ctx context.Context, d *schema.ResourceData, meta inter
 			ProjectIdentifier: helpers.BuildField(d, "project_id"),
 			Identifiers:       optional.NewInterface(id),
 		})
-		tokenList := resp.Data.Content
 		if err != nil {
 			return helpers.HandleApiError(err, d, httpResp)
 		}
+		tokenList := resp.Data.Content
 
 		if tokenList == nil || len(tokenList) == 0 {
 			d.SetId("")


### PR DESCRIPTION
## Describe your changes
Account_id is missing in the data_source docs of apiToken
Also fixed the crashing of the data source for apiKey.
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
