### PR TITLE
fix: gcp ccm connector no billing export

### DIFF
--- a/internal/service/platform/connector/gcp_cloud_cost.go
+++ b/internal/service/platform/connector/gcp_cloud_cost.go
@@ -136,12 +136,14 @@ func readConnectorGCPCloudCost(d *schema.ResourceData, connector *nextgen.Connec
 	d.Set("features_enabled", connector.GcpCloudCost.FeaturesEnabled)
 	d.Set("gcp_project_id", connector.GcpCloudCost.ProjectId)
 	d.Set("service_account_email", connector.GcpCloudCost.ServiceAccountEmail)
-	d.Set("billing_export_spec", []interface{}{
-		map[string]interface{}{
-			"data_set_id": connector.GcpCloudCost.BillingExportSpec.DatasetId,
-			"table_id":    connector.GcpCloudCost.BillingExportSpec.TableId,
-		},
-	})
+	if isFeatureEnabled("BILLING", connector.GcpCloudCost.FeaturesEnabled) {
+		d.Set("billing_export_spec", []interface{}{
+			map[string]interface{}{
+				"data_set_id": connector.GcpCloudCost.BillingExportSpec.DatasetId,
+				"table_id":    connector.GcpCloudCost.BillingExportSpec.TableId,
+			},
+		})
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Describe your changes

Currently we cannot create gcp ccm connectors without a billing export due to a bug where we check for the export on every call:

```
➜  test tf apply
main.tf

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # harness_platform_connector_gcp_cloud_cost.example will be created
  + resource "harness_platform_connector_gcp_cloud_cost" "example" {
      + features_enabled      = [
          + "OPTIMIZATION",
          + "VISIBILITY",
        ]
      + gcp_project_id        = "gcp_project_id"
      + id                    = (known after apply)
      + identifier            = "example"
      + name                  = "example"
      + service_account_email = "sdfsdfsdf@google.com"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

harness_platform_connector_gcp_cloud_cost.example: Creating...
╷
│ Error: Plugin did not respond
│ 
│   with harness_platform_connector_gcp_cloud_cost.example,
│   on main.tf line 21, in resource "harness_platform_connector_gcp_cloud_cost" "example":
│   21: resource "harness_platform_connector_gcp_cloud_cost" "example" {
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-harness_v0.23.3 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10388ab0c]

goroutine 7 [running]:
github.com/harness/terraform-provider-harness/internal/service/platform/connector.readConnectorGCPCloudCost(0x103e07908?, 0x140003a8380)
        github.com/harness/terraform-provider-harness/internal/service/platform/connector/gcp_cloud_cost.go:141 +0xdc
github.com/harness/terraform-provider-harness/internal/service/platform/connector.resourceConnectorGCPCloudCostCreateOrUpdate({0x103e07908, 0x14000694ae0}, 0x0?, {0x103cc67e0, 0x140009945c0})
        github.com/harness/terraform-provider-harness/internal/service/platform/connector/gcp_cloud_cost.go:94 +0x64
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x140004fc000, {0x103e07940, 0x1400060e360}, 0xd?, {0x103cc67e0, 0x140009945c0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:733 +0xec
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x140004fc000, {0x103e07940, 0x1400060e360}, 0x140008e29c0, 0x140008db100, {0x103cc67e0, 0x140009945c0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:864 +0x898
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x1400000c060, {0x103e07940?, 0x1400060e240?}, 0x14000402910)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/grpc_provider.go:1024 +0xb94
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140002fa280, {0x103e07940?, 0x140008f3ce0?}, 0x140008d0150)
        github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/tf5server/server.go:821 +0x3c0
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x103dad340?, 0x140002fa280}, {0x103e07940, 0x140008f3ce0}, 0x140008d00e0, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:422 +0x174
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400044e000, {0x103e0a8e0, 0x14000102d00}, 0x140008e07e0, 0x140000ad710, 0x10447a960, 0x0)
        google.golang.org/grpc@v1.56.2/server.go:1337 +0xc7c
google.golang.org/grpc.(*Server).handleStream(0x1400044e000, {0x103e0a8e0, 0x14000102d00}, 0x140008e07e0, 0x0)
        google.golang.org/grpc@v1.56.2/server.go:1714 +0x840
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        google.golang.org/grpc@v1.56.2/server.go:959 +0x88
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.56.2/server.go:957 +0x170

Error: The terraform-provider-harness_v0.23.3 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

By optionally checking for the billing export, only when BILLING is set, we can successfully create gcp ccm connectors without cost connectors:

```
➜  tttt tf apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - harness/harness in /Users/rileysnyder/git/terraform-provider-harness
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # harness_platform_connector_gcp_cloud_cost.gcp will be created
  + resource "harness_platform_connector_gcp_cloud_cost" "gcp" {
      + features_enabled      = [
          + "OPTIMIZATION",
          + "VISIBILITY",
        ]
      + gcp_project_id        = "gcp_project_id"
      + id                    = (known after apply)
      + identifier            = "gcp"
      + name                  = "gcp"
      + service_account_email = "sdfsdfsdf@google.com"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

harness_platform_connector_gcp_cloud_cost.gcp: Creating...
harness_platform_connector_gcp_cloud_cost.gcp: Creation complete after 0s [id=gcp]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
