### PR TITLE
fix: [CDS-76802]: Set as new resource for empty get call

### DIFF
--- a/internal/service/platform/service_overrides_v2/resource_service_overrides_v2.go
+++ b/internal/service/platform/service_overrides_v2/resource_service_overrides_v2.go
@@ -82,6 +82,14 @@ func resourceServiceOverridesV2Read(ctx context.Context, d *schema.ResourceData,
 		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
+	// GET call for service environment override returns a 200 ok for empty list.
+	// Hence specifically marking the resource as new, instead of in L#91
+	if &resp == nil || resp.Data == nil {
+		d.SetId("")
+		d.MarkNewResource()
+		return nil
+	}
+
 	readServiceOverridesV2(d, resp.Data)
 
 	return nil


### PR DESCRIPTION
## Describe your changes
- The service override list call returns 200 ok for empty responses. In this case, we must mark the resource as a new resource in state file. 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
