### PR TITLE
fix: [CDS-76802]: Mark resource as new

### DIFF
--- a/internal/service/platform/environment_service_overrides/resource_environment_service_overrides.go
+++ b/internal/service/platform/environment_service_overrides/resource_environment_service_overrides.go
@@ -63,8 +63,15 @@ func resourceEnvironmentServiceOverridesRead(ctx context.Context, d *schema.Reso
 			OrgIdentifier:     helpers.BuildField(d, "org_id"),
 			ProjectIdentifier: helpers.BuildField(d, "project_id"),
 		})
+
 	if err != nil {
 		return helpers.HandleReadApiError(err, d, httpResp)
+	}
+
+	if resp.Data == nil || len(resp.Data.Content) == 0 {
+		d.SetId("")
+		d.MarkNewResource()
+		return nil
 	}
 
 	readEnvironmentServiceOverridesList(d, resp.Data)


### PR DESCRIPTION
## Describe your changes
- The service env override list call returns 200 ok for empty responses. In this case, we must mark the resource as a new resource in state file.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
