### PR TITLE
fix: [CDS-78671]: Make file content optional

### DIFF
--- a/.changelog/681.txt
+++ b/.changelog/681.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-harness_platform_file_store_folder -  Make file content optional, if the file content is provided use it directly else get the content from file path. 
+harness_platform_file_store_file -  Make file content optional, if the file content is provided use it directly else get the content from file path. 
 ```

--- a/.changelog/681.txt
+++ b/.changelog/681.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Make file content optional, if the file content is provided use it directly else get the content from file path. 
+```

--- a/.changelog/681.txt
+++ b/.changelog/681.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Make file content optional, if the file content is provided use it directly else get the content from file path. 
+harness_platform_file_store_folder -  Make file content optional, if the file content is provided use it directly else get the content from file path. 
 ```

--- a/internal/service/platform/file_store/resource_file.go
+++ b/internal/service/platform/file_store/resource_file.go
@@ -51,8 +51,7 @@ func ResourceFileStoreNodeFile() *schema.Resource {
 			"content": {
 				Description: "File content stored on Harness File Store",
 				Type:        schema.TypeString,
-				Optional:    false,
-				Computed:    true,
+				Optional:    true,
 			},
 			"path": {
 				Description: "Harness File Store file path",
@@ -201,7 +200,7 @@ func resourceFileStoreNodeFileDelete(ctx context.Context, d *schema.ResourceData
 }
 
 func buildFileStoreApiFileCreateRequest(d *schema.ResourceData) (*nextgen.FileStoreApiCreateOpts, error) {
-	fileContent, err := getFileContent(d.Get(fileContentPath))
+	fileContent, err := getFileContent(d.Get(fileContentPath), d.Get(content))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +229,7 @@ func buildFileStoreApiFileCreateRequest(d *schema.ResourceData) (*nextgen.FileSt
 }
 
 func buildFileStoreApiFileUpdateRequest(d *schema.ResourceData) (*nextgen.FileStoreApiUpdateOpts, error) {
-	fileContent, err := getFileContent(d.Get(fileContentPath))
+	fileContent, err := getFileContent(d.Get(fileContentPath), d.Get(content))
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +292,11 @@ func readFileNode(d *schema.ResourceData, file *nextgen.File, fileContentOpt opt
 	d.Set(content, fileContent)
 }
 
-func getFileContent(filePath interface{}) (optional.Interface, error) {
+func getFileContent(filePath interface{}, fileContent interface{}) (optional.Interface, error) {
+	if fileContentStr, ok := fileContent.(string); ok && len(fileContentStr) > 0 {
+		// If fileContent is a non-empty string, return it directly
+		return optional.NewInterface([]byte(fileContentStr)), nil
+	}
 	filePathStr, ok := filePath.(string)
 	if !ok {
 		return optional.Interface{}, nil


### PR DESCRIPTION
## Describe your changes
Previously if file content is changed terraform plan would make no change to tfstate file as file content is computed, this change will make file content field as optional from computed to fetch the file content directly.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
