### PR TITLE
fix: [CDS-79070]: Set cross_account_access

### DIFF
--- a/.changelog/687.txt
+++ b/.changelog/687.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+harness_platform_connector_aws -  Set value for cross_account_access if not nil.
+```

--- a/internal/service/platform/connector/aws.go
+++ b/internal/service/platform/connector/aws.go
@@ -395,6 +395,14 @@ func readConnectorAws(d *schema.ResourceData, connector *nextgen.ConnectorInfo) 
 	default:
 		return fmt.Errorf("unsupported aws credential type: %s", connector.Aws.Credential.Type_)
 	}
+	if connector.Aws.Credential.CrossAccountAccess != nil {
+		d.Set("cross_account_access", []map[string]interface{}{
+			{
+				"role_arn":    connector.Aws.Credential.CrossAccountAccess.CrossAccountRoleArn,
+				"external_id": connector.Aws.Credential.CrossAccountAccess.ExternalId,
+			},
+		})
+	}
 	if connector.Aws.AwsSdkClientBackOffStrategyOverride != nil {
 		switch connector.Aws.AwsSdkClientBackOffStrategyOverride.Type_ {
 		case nextgen.AwsSdkClientBackOffStrategyTypes.EqualJitterBackoffStrategy:

--- a/internal/service/platform/connector/aws_data_source_test.go
+++ b/internal/service/platform/connector/aws_data_source_test.go
@@ -58,6 +58,7 @@ func TestAccDataSourceConnectorAwsFullJitterBackOff(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "full_jitter_backoff_strategy.0.retry_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "full_jitter_backoff_strategy.0.base_delay", "10"),
 					resource.TestCheckResourceAttr(resourceName, "full_jitter_backoff_strategy.0.max_backoff_time", "65"),
+					resource.TestCheckResourceAttr(resourceName, "cross_account_access.0.role_arn", "test"),
 				),
 			},
 		},
@@ -179,6 +180,9 @@ func testAccDataSourceConnectorAwsFullJitterBackOff(name string) string {
 				base_delay = 10
 				max_backoff_time = 65
 				retry_count = 3
+			}
+			cross_account_access {
+				role_arn = "test"
 			}
 		}
 


### PR DESCRIPTION
## Describe your changes
harness_platform_connector_aws -  Set value for cross_account_access if not nil.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
