### PR TITLE
fix: resource_feature_flag_target_group project_id

### DIFF
--- a/docs/resources/platform_feature_flag_target_group.md
+++ b/docs/resources/platform_feature_flag_target_group.md
@@ -15,7 +15,7 @@ Resource for creating a Harness Feature Flag Target Group.
 ```terraform
 resource "harness_platform_feature_flag_target_group" "target" {
   org_id     = "test"
-  project    = "test"
+  project_id = "test"
 
   identifier  = "MY_FEATURE"
   environment = "MY_ENVIRONMENT"
@@ -43,7 +43,7 @@ resource "harness_platform_feature_flag_target_group" "target" {
 - `identifier` (String) The unique identifier of the feature flag target group.
 - `name` (String) The name of the feature flag target group.
 - `org_id` (String) Organization Identifier
-- `project` (String) Project Identifier
+- `project_id` (String) Project Identifier
 
 ### Optional
 

--- a/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
+++ b/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
@@ -38,7 +38,7 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"project": {
+			"project_id": {
 				Description: "Project Identifier",
 				Type:        schema.TypeString,
 				Required:    true,
@@ -272,7 +272,7 @@ func buildFFTargetGroupQueryParameters(d *schema.ResourceData) *FFTargetGroupQue
 	return &FFTargetGroupQueryParameters{
 		Identifier:  d.Get("identifier").(string),
 		OrgID:       d.Get("org_id").(string),
-		Project:     d.Get("project").(string),
+		Project:     d.Get("project_id").(string),
 		AcountID:    d.Get("account_id").(string),
 		Environment: d.Get("environment").(string),
 	}
@@ -282,7 +282,7 @@ func buildFFTargetGroupQueryParameters(d *schema.ResourceData) *FFTargetGroupQue
 func buildSegmentRequest(d *schema.ResourceData) *SegmentRequest {
 	opts := &SegmentRequest{
 		Identifier:  d.Get("identifier").(string),
-		Project:     d.Get("project").(string),
+		Project:     d.Get("project_id").(string),
 		Environment: d.Get("environment").(string),
 		Name:        d.Get("name").(string),
 	}

--- a/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group_test.go
+++ b/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group_test.go
@@ -30,7 +30,7 @@ func TestAccResourceFeatureFlagTargetGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
-					resource.TestCheckResourceAttr(resourceName, "project", id),
+					resource.TestCheckResourceAttr(resourceName, "project_id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", targetName),
 				),
 			},
@@ -39,7 +39,7 @@ func TestAccResourceFeatureFlagTargetGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "identifier", id),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
-					resource.TestCheckResourceAttr(resourceName, "project", id),
+					resource.TestCheckResourceAttr(resourceName, "project_id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", targetName),
 				),
 			},
@@ -125,7 +125,7 @@ func testAccResourceFeatureFlagTarget(id string, name string, updatedName string
 		resource "harness_platform_feature_flag_target_group" "test" {
 			identifier = "%[1]s"
 			org_id = harness_platform_project.test.org_id
-			project = harness_platform_project.test.id
+			project_id = harness_platform_project.test.id
 			environment = harness_platform_environment.test.id
 			account_id = harness_platform_project.test.id
 			name = "%[2]s"


### PR DESCRIPTION
## Describe your changes

All other harness tf resource use project_id rather than project, use the same here.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
