### PR TITLE
FFM-9404: harness_platform_feature_flag cannot add targeting rules

### DIFF
--- a/.changelog/699.txt
+++ b/.changelog/699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+harness_platform_feature_flag -  Enable adding target and target groups through features
+```

--- a/docs/resources/platform_feature_flag.md
+++ b/docs/resources/platform_feature_flag.md
@@ -85,6 +85,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
   kind       = "int"
   name       = "FREE_TRIAL_DURATION"
   identifier = "FREE_TRIAL_DURATION"
+  environment = "MY_ENVIRONMENT"
   permanent  = false
 
   default_on_variation  = "trial7"
@@ -111,7 +112,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
     value       = "20"
   }
 
-  add_target_rules {
+  add_target_rule {
     variation = "trial14"
     targets = ["targets1", "targets2"]
   }
@@ -125,6 +126,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
   kind       = "int"
   name       = "FREE_TRIAL_DURATION"
   identifier = "FREE_TRIAL_DURATION"
+  environment = "MY_ENVIRONMENT"
   permanent  = false
 
   default_on_variation  = "trial7"
@@ -151,7 +153,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
     value       = "20"
   }
 
-  add_target_groups_rules {
+  add_target_groups_rule {
     group_name = "group_name"
     variation = "trial14"
     distribution = {
@@ -191,9 +193,10 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
 
 ### Optional
 
-- `add_target_group_rules` (Block List) The targeting rules for the flag (see [below for nested schema](#nestedblock--add_target_group_rules))
-- `add_target_rules` (Block List) The targeting rules for the flag (see [below for nested schema](#nestedblock--add_target_rules))
+- `add_target_group_rule` (Block List) The targeting rules for the flag (see [below for nested schema](#nestedblock--add_target_group_rule))
+- `add_target_rule` (Block List) The targeting rules for the flag (see [below for nested schema](#nestedblock--add_target_rule))
 - `archived` (Boolean) Whether or not the flag is archived
+- `environment` (String) Environment Identifier
 - `git_details` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--git_details))
 - `owner` (String) The owner of the flag
 
@@ -212,24 +215,24 @@ Required:
 - `value` (String) The value of the variation
 
 
-<a id="nestedblock--add_target_group_rules"></a>
-### Nested Schema for `add_target_group_rules`
+<a id="nestedblock--add_target_group_rule"></a>
+### Nested Schema for `add_target_group_rule`
 
 Optional:
 
-- `distribution` (Block List) The distribution of the rule (see [below for nested schema](#nestedblock--add_target_group_rules--distribution))
+- `distribution` (Block List) The distribution of the rule (see [below for nested schema](#nestedblock--add_target_group_rule--distribution))
 - `group_name` (String) The name of the target group
 - `variation` (String) The identifier of the variation. Valid values are `enabled`, `disabled`
 
-<a id="nestedblock--add_target_group_rules--distribution"></a>
-### Nested Schema for `add_target_group_rules.distribution`
+<a id="nestedblock--add_target_group_rule--distribution"></a>
+### Nested Schema for `add_target_group_rule.distribution`
 
 Optional:
 
-- `variations` (Block List) The variations of the rule (see [below for nested schema](#nestedblock--add_target_group_rules--distribution--variations))
+- `variations` (Block List) The variations of the rule (see [below for nested schema](#nestedblock--add_target_group_rule--distribution--variations))
 
-<a id="nestedblock--add_target_group_rules--distribution--variations"></a>
-### Nested Schema for `add_target_group_rules.distribution.variations`
+<a id="nestedblock--add_target_group_rule--distribution--variations"></a>
+### Nested Schema for `add_target_group_rule.distribution.variations`
 
 Optional:
 
@@ -239,8 +242,8 @@ Optional:
 
 
 
-<a id="nestedblock--add_target_rules"></a>
-### Nested Schema for `add_target_rules`
+<a id="nestedblock--add_target_rule"></a>
+### Nested Schema for `add_target_rule`
 
 Optional:
 

--- a/examples/resources/harness_platform_feature_flag/resource.tf
+++ b/examples/resources/harness_platform_feature_flag/resource.tf
@@ -70,6 +70,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
   kind       = "int"
   name       = "FREE_TRIAL_DURATION"
   identifier = "FREE_TRIAL_DURATION"
+  environment = "MY_ENVIRONMENT"
   permanent  = false
 
   default_on_variation  = "trial7"
@@ -110,6 +111,7 @@ resource "harness_platform_feature_flag" "mymultivariateflag" {
   kind       = "int"
   name       = "FREE_TRIAL_DURATION"
   identifier = "FREE_TRIAL_DURATION"
+  environment = "MY_ENVIRONMENT"
   permanent  = false
 
   default_on_variation  = "trial7"

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.45.12 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.45.12 h1:+bKbbesGNPp+TeGrcqfrWuZoqcIEhjwKyBMHQPp80Jo=
+github.com/aws/aws-sdk-go v1.45.12/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
@@ -130,6 +132,8 @@ github.com/jhump/protoreflect v1.6.1 h1:4/2yi5LyDPP7nN+Hiird1SAJ6YoxUm13/oxHGRnb
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -255,6 +259,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
@@ -286,6 +291,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -294,6 +300,7 @@ golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=
@@ -339,6 +346,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
 	"github.com/harness/terraform-provider-harness/helpers"
 	"github.com/harness/terraform-provider-harness/internal"
@@ -228,9 +229,9 @@ var KindMap = map[string]string{
 
 // TargetRules is the target rules for the feature flag
 type TargetRules struct {
-	Kind      string   `json:"kind,omitempty"`
-	Variation string   `json:"variation,omitempty"`
-	Targets   []string `json:"targets,omitempty"`
+	Kind      string    `json:"kind,omitempty"`
+	Variation string    `json:"variation,omitempty"`
+	Targets   []*string `json:"targets,omitempty"`
 }
 
 // Variation is the variation for the feature flag
@@ -254,17 +255,17 @@ type TargetGroupRules struct {
 
 // Serve ...
 type Serve struct {
-	Variation    string       `json:"variation,omitempty"`
-	Distribution Distribution `json:"distribution,omitempty"`
+	Variation    string        `json:"variation,omitempty"`
+	Distribution *Distribution `json:"distribution,omitempty"`
 }
 
 // Parameter ...
 type Parameter struct {
-	Variation string           `json:"variation,omitempty"`
-	Targets   []string         `json:"targets,omitempty"`
-	Priority  string           `json:"priority,omitempty"`
-	Clauses   []nextgen.Clause `json:"clauses,omitempty"`
-	Serve     Serve            `json:"serve,omitempty"`
+	Variation string            `json:"variation,omitempty"`
+	Targets   []*string         `json:"targets,omitempty"`
+	Priority  string            `json:"priority,omitempty"`
+	Clauses   []*nextgen.Clause `json:"clauses,omitempty"`
+	Serve     *Serve            `json:"serve,omitempty"`
 }
 
 // Instruction defines the instruction for the feature flag
@@ -376,6 +377,15 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 		return helpers.HandleApiError(err, d, httpResp)
 	}
 
+	patchOpts := buildFFPatchOpts(d)
+
+	// update the feature flag with the git details
+	_, httpResp, err = c.FeatureFlagsApi.PatchFeature(ctx, c.AccountId, qp.OrganizationId, qp.ProjectId, id, patchOpts)
+
+	if err != nil {
+		return helpers.HandleApiError(err, d, httpResp)
+	}
+
 	resp, httpResp, err = c.FeatureFlagsApi.GetFeatureFlag(ctx, id, c.AccountId, qp.OrganizationId, qp.ProjectId, readOpts)
 
 	if err != nil {
@@ -383,15 +393,6 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	readFeatureFlag(d, &resp, qp)
-
-	// patchOpts := buildFFPatchOpts(d)
-
-	// update the feature flag with the git details
-	// feature, httpResp, err := c.FeatureFlagsApi.PatchFeature(ctx, c.AccountId, qp.OrganizationId, qp.ProjectId, id, patchOpts)
-
-	// if err != nil {
-	//	return helpers.HandleApiError(err, d, httpResp)
-	// }
 
 	return nil
 }
@@ -529,25 +530,32 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 	}
 	opts.Variations = variations
 
-	var targetRules []TargetRules
+	var instructions []Instruction
 	if targetRulesData, ok := d.GetOk("add_target_rule"); ok {
 		for _, targetRuleData := range targetRulesData.([]interface{}) {
 			vMap := targetRuleData.(map[string]interface{})
-			var targets []string = make([]string, 0)
+			var targets []*string = make([]*string, 0)
 			for _, target := range vMap["targets"].([]interface{}) {
-				targets = append(targets, target.(string))
+				targets = append(targets, aws.String(target.(string)))
 			}
 			targetRule := TargetRules{
 				Kind:      "addTargetsToVariationTargetMap",
 				Variation: vMap["variation"].(string),
 				Targets:   targets,
 			}
-			targetRules = append(targetRules, targetRule)
+			instruction := Instruction{
+				Kind: targetRule.Kind,
+				Parameters: Parameter{
+					Variation: targetRule.Variation,
+					Targets:   targetRule.Targets,
+					Clauses:   nil,
+					Serve:     nil,
+				},
+			}
+			instructions = append(instructions, instruction)
 		}
 	}
 
-	var targetGroupRules []TargetGroupRules
-	var distribution Distribution
 	if targetGroupRulesData, ok := d.GetOk("add_target_group_rule"); ok {
 		for _, targetGroupRuleData := range targetGroupRulesData.([]interface{}) {
 			vMap := targetGroupRuleData.(map[string]interface{})
@@ -557,55 +565,42 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 				Variation: vMap["variation"].(string),
 			}
 
-			for _, distributionData := range vMap["distribution"].([]interface{}) {
-				vMap := distributionData.(map[string]interface{})
-				distribution = Distribution{
-					BuckedBy: "identifier",
-				}
-				var variations []Variation
-				for _, variationData := range vMap["variations"].([]interface{}) {
-					vMap := variationData.(map[string]interface{})
-					variation := Variation{
-						Variation: vMap["variation"].(string),
-						Weight:    vMap["weight"].(int),
+			var distribution *Distribution = nil
+			if distrib, ok := vMap["distribution"]; ok {
+				for _, distributionData := range distrib.([]interface{}) {
+					vMap := distributionData.(map[string]interface{})
+					distribution = &Distribution{
+						BuckedBy: "identifier",
 					}
-					variations = append(variations, variation)
+					var variations []Variation
+					for _, variationData := range vMap["variations"].([]interface{}) {
+						vMap := variationData.(map[string]interface{})
+						variation := Variation{
+							Variation: vMap["variation"].(string),
+							Weight:    vMap["weight"].(int),
+						}
+						variations = append(variations, variation)
+					}
+					distribution.Variations = variations
 				}
-				distribution.Variations = variations
 			}
-			targetGroupRules = append(targetGroupRules, targetGroupRule)
-		}
-	}
-
-	var instructions []Instruction
-	for _, target := range targetRules {
-		instruction := Instruction{
-			Kind: target.Kind,
-			Parameters: Parameter{
-				Variation: target.Variation,
-				Targets:   target.Targets,
-			},
-		}
-		instructions = append(instructions, instruction)
-	}
-
-	for _, targetGroup := range targetGroupRules {
-		instruction := Instruction{
-			Kind: targetGroup.Kind,
-			Parameters: Parameter{
-				Serve: Serve{
-					Variation:    targetGroup.Variation,
-					Distribution: distribution,
-				},
-				Clauses: []nextgen.Clause{
-					{
-						Op:     "segmentMatch",
-						Values: []string{targetGroup.GroupName},
+			instruction := Instruction{
+				Kind: targetGroupRule.Kind,
+				Parameters: Parameter{
+					Serve: &Serve{
+						Variation:    targetGroupRule.Variation,
+						Distribution: distribution,
+					},
+					Clauses: []*nextgen.Clause{
+						{
+							Op:     "segmentMatch",
+							Values: []string{targetGroupRule.GroupName},
+						},
 					},
 				},
-			},
+			}
+			instructions = append(instructions, instruction)
 		}
-		instructions = append(instructions, instruction)
 	}
 
 	opts.Instructions = instructions

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -212,6 +212,16 @@ func ResourceFeatureFlag() *schema.Resource {
 	return resource
 }
 
+const (
+	Variation                      = "variation"
+	Weight                         = "weight"
+	AddTargetsToVariationTargetMap = "addTargetsToVariationTargetMap"
+	AddRule                        = "addRule"
+	Description                    = "description"
+	segmentMatch                   = "segmentMatch"
+	BuckedBy                       = "identifier"
+)
+
 type FFQueryParameters struct {
 	Identifier     string
 	OrganizationId string
@@ -539,8 +549,8 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 				targets = append(targets, aws.String(target.(string)))
 			}
 			targetRule := TargetRules{
-				Kind:      "addTargetsToVariationTargetMap",
-				Variation: vMap["variation"].(string),
+				Kind:      AddTargetsToVariationTargetMap,
+				Variation: vMap[Variation].(string),
 				Targets:   targets,
 			}
 			instruction := Instruction{
@@ -560,24 +570,24 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 		for _, targetGroupRuleData := range targetGroupRulesData.([]interface{}) {
 			vMap := targetGroupRuleData.(map[string]interface{})
 			targetGroupRule := TargetGroupRules{
-				Kind:      "addRule",
-				GroupName: vMap["group_name"].(string),
-				Variation: vMap["variation"].(string),
+				Kind:      AddRule,
+				GroupName: vMap[GroupName].(string),
+				Variation: vMap[Variation].(string),
 			}
 
 			var distribution *Distribution = nil
-			if distrib, ok := vMap["distribution"]; ok {
+			if distrib, ok := vMap[Distribution]; ok {
 				for _, distributionData := range distrib.([]interface{}) {
 					vMap := distributionData.(map[string]interface{})
 					distribution = &Distribution{
-						BuckedBy: "identifier",
+						BuckedBy: BuckedBy,
 					}
 					var variations []Variation
 					for _, variationData := range vMap["variations"].([]interface{}) {
 						vMap := variationData.(map[string]interface{})
 						variation := Variation{
-							Variation: vMap["variation"].(string),
-							Weight:    vMap["weight"].(int),
+							Variation: vMap[Variation].(string),
+							Weight:    vMap[Weight].(int),
 						}
 						variations = append(variations, variation)
 					}
@@ -593,7 +603,7 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 					},
 					Clauses: []*nextgen.Clause{
 						{
-							Op:     "segmentMatch",
+							Op:     SegmentMatch,
 							Values: []string{targetGroupRule.GroupName},
 						},
 					},

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -213,12 +213,13 @@ func ResourceFeatureFlag() *schema.Resource {
 }
 
 const (
-	Variation                      = "variation"
+	VariationVar                   = "variation"
 	Weight                         = "weight"
 	AddTargetsToVariationTargetMap = "addTargetsToVariationTargetMap"
 	AddRule                        = "addRule"
-	Description                    = "description"
-	segmentMatch                   = "segmentMatch"
+	GroupName                      = "group_name"
+	DistributionVar                = "distribution"
+	SegmentMatch                   = "segmentMatch"
 	BuckedBy                       = "identifier"
 )
 
@@ -550,7 +551,7 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 			}
 			targetRule := TargetRules{
 				Kind:      AddTargetsToVariationTargetMap,
-				Variation: vMap[Variation].(string),
+				Variation: vMap[VariationVar].(string),
 				Targets:   targets,
 			}
 			instruction := Instruction{
@@ -572,11 +573,11 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 			targetGroupRule := TargetGroupRules{
 				Kind:      AddRule,
 				GroupName: vMap[GroupName].(string),
-				Variation: vMap[Variation].(string),
+				Variation: vMap[VariationVar].(string),
 			}
 
 			var distribution *Distribution = nil
-			if distrib, ok := vMap[Distribution]; ok {
+			if distrib, ok := vMap[DistributionVar]; ok {
 				for _, distributionData := range distrib.([]interface{}) {
 					vMap := distributionData.(map[string]interface{})
 					distribution = &Distribution{
@@ -586,7 +587,7 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 					for _, variationData := range vMap["variations"].([]interface{}) {
 						vMap := variationData.(map[string]interface{})
 						variation := Variation{
-							Variation: vMap[Variation].(string),
+							Variation: vMap[VariationVar].(string),
 							Weight:    vMap[Weight].(int),
 						}
 						variations = append(variations, variation)

--- a/internal/service/platform/feature_flag/resource_feature_flag_test.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag_test.go
@@ -150,11 +150,11 @@ func testAccResourceFeatureFlag(id string, name string, updatedName string) stri
 
 		resource "harness_platform_feature_flag_target_group" "targetgroup1" {
 			identifier = "targetgroup1"
+			name = "targetgroup1"
 			org_id = harness_platform_project.test.org_id
 			project_id = harness_platform_project.test.id
 			environment = harness_platform_environment.test.id
 			account_id = harness_platform_project.test.id
-			name = "targetgroup1"
 			included = []
 			excluded = []
 			rule {
@@ -162,6 +162,15 @@ func testAccResourceFeatureFlag(id string, name string, updatedName string) stri
 				op        = "equal"
 				values    = [harness_platform_feature_flag_target.target1.id]
 			}
+		}
+
+		resource "harness_platform_feature_flag_target_group" "targetgroup2" {
+			identifier = "targetgroup2"
+			name = "targetgroup2"
+			org_id = harness_platform_project.test.org_id
+			project_id = harness_platform_project.test.id
+			environment = harness_platform_environment.test.id
+			account_id = harness_platform_project.test.id
 		}
 
 		resource "harness_platform_feature_flag" "test" {
@@ -192,12 +201,26 @@ func testAccResourceFeatureFlag(id string, name string, updatedName string) stri
 
 			add_target_rule {
 				variation = "Enabled"
-				targets = ["targets1"]
+				targets = ["target1"]
 			}
 
 			add_target_group_rule {
 				variation = "Enabled"
 				group_name = "targetgroup1"
+			}
+
+			add_target_group_rule {
+				group_name = "targetgroup2"
+				distribution {
+					variations {
+						variation = "Enabled"
+						weight = 50
+					}
+					variations {
+						variation = "Disabled"
+						weight = 50
+					}
+				}
 			}
 		}
 `, id, name, updatedName)


### PR DESCRIPTION
## Describe your changes

With this change, it is now possible to assign targets and target groups to feature flags on creation. Updates are still limited to the issue in FFM-9600, however, previously we failed to create rules due to an issue in the schema. This change fixes the schema for rules configuration during feature flag creation.

The test cases for this change include:
* Create flag
* add rules to flag
* create flag with rules
* remove rule

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
