### PR TITLE
FFM-9400: TF: harness_platform_feature_flag_target_group does not update

### DIFF
--- a/.changelog/700.txt
+++ b/.changelog/700.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+harness_platform_feature_flag -  Fix updates on targets, target groups and feature flags.
+```

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -92,14 +92,11 @@ func ResourceFeatureFlag() *schema.Resource {
 				Description: "The owner of the flag",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
 			},
 			"permanent": {
 				Description: "Whether or not the flag is permanent. If it is, it will never be flagged as stale",
 				Type:        schema.TypeBool,
 				Required:    true,
-				ForceNew:    true,
 			},
 			"environment": {
 				Description: "Environment Identifier",

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -217,6 +217,8 @@ const (
 	Weight                         = "weight"
 	AddTargetsToVariationTargetMap = "addTargetsToVariationTargetMap"
 	AddRule                        = "addRule"
+	RemoveRule                     = "removeRule"
+	RemoveTarget                   = "removeTargetsToVariationTargetMap"
 	GroupName                      = "group_name"
 	DistributionVar                = "distribution"
 	SegmentMatch                   = "segmentMatch"

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -251,49 +251,49 @@ var KindMap = map[string]string{
 
 // TargetRules is the target rules for the feature flag
 type TargetRules struct {
-	Kind      string    `json:"kind,omitempty"`
-	Variation string    `json:"variation,omitempty"`
+	Kind      *string   `json:"kind,omitempty"`
+	Variation *string   `json:"variation,omitempty"`
 	Targets   []*string `json:"targets,omitempty"`
 }
 
 // Variation is the variation for the feature flag
 type Variation struct {
-	Variation string `json:"variation,omitempty"`
-	Weight    int    `json:"weight,omitempty"`
+	Variation *string `json:"variation,omitempty"`
+	Weight    *int    `json:"weight,omitempty"`
 }
 
 // Distribution is the distribution for the feature flag
 type Distribution struct {
-	BuckedBy   string      `json:"buckedBy,omitempty"`
-	Variations []Variation `json:"variations,omitempty"`
+	BuckedBy   *string      `json:"buckedBy,omitempty"`
+	Variations []*Variation `json:"variations,omitempty"`
 }
 
 // TargetGroupRules is the target group rules for the feature flag
 type TargetGroupRules struct {
-	Kind      string `json:"kind,omitempty"`
-	GroupName string `json:"groupName,omitempty"`
-	Variation string `json:"variation,omitempty"`
+	Kind      *string `json:"kind,omitempty"`
+	GroupName *string `json:"groupName,omitempty"`
+	Variation *string `json:"variation,omitempty"`
 }
 
 // Serve ...
 type Serve struct {
-	Variation    string        `json:"variation,omitempty"`
+	Variation    *string       `json:"variation,omitempty"`
 	Distribution *Distribution `json:"distribution,omitempty"`
 }
 
 // Parameter ...
 type Parameter struct {
-	Variation string            `json:"variation,omitempty"`
+	Variation *string           `json:"variation,omitempty"`
 	Targets   []*string         `json:"targets,omitempty"`
-	Priority  string            `json:"priority,omitempty"`
+	Priority  *string           `json:"priority,omitempty"`
 	Clauses   []*nextgen.Clause `json:"clauses,omitempty"`
 	Serve     *Serve            `json:"serve,omitempty"`
 }
 
 // Instruction defines the instruction for the feature flag
 type Instruction struct {
-	Kind       string    `json:"kind,omitempty"`
-	Parameters Parameter `json:"parameters,omitempty"`
+	Kind       *string    `json:"kind,omitempty"`
+	Parameters *Parameter `json:"parameters,omitempty"`
 }
 
 type FFOpts struct {
@@ -310,7 +310,7 @@ type FFOpts struct {
 	Permanent           bool                `json:"permanent"`
 	Project             string              `json:"project"`
 	Variations          []nextgen.Variation `json:"variations"`
-	Instructions        []Instruction       `json:"instructions,omitempty"`
+	Instructions        []*Instruction      `json:"instructions,omitempty"`
 }
 
 // FFPatchOpts is the options for patching a feature flag
@@ -328,7 +328,7 @@ type FFPatchOpts struct {
 	Permanent           bool                `json:"permanent"`
 	Project             string              `json:"project"`
 	Variations          []nextgen.Variation `json:"variations"`
-	Instructions        []Instruction       `json:"instructions,omitempty"`
+	Instructions        []*Instruction      `json:"instructions,omitempty"`
 }
 
 func resourceFeatureFlagUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -552,7 +552,7 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 	}
 	opts.Variations = variations
 
-	var instructions []Instruction
+	var instructions []*Instruction
 	if targetRulesData, ok := d.GetOk("add_target_rule"); ok {
 		for _, targetRuleData := range targetRulesData.([]interface{}) {
 			vMap := targetRuleData.(map[string]interface{})
@@ -561,13 +561,13 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 				targets = append(targets, aws.String(target.(string)))
 			}
 			targetRule := TargetRules{
-				Kind:      AddTargetsToVariationTargetMap,
-				Variation: vMap[VariationVar].(string),
+				Kind:      aws.String(AddTargetsToVariationTargetMap),
+				Variation: aws.String(vMap[VariationVar].(string)),
 				Targets:   targets,
 			}
-			instruction := Instruction{
+			instruction := &Instruction{
 				Kind: targetRule.Kind,
-				Parameters: Parameter{
+				Parameters: &Parameter{
 					Variation: targetRule.Variation,
 					Targets:   targetRule.Targets,
 					Clauses:   nil,
@@ -582,9 +582,9 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 		for _, targetGroupRuleData := range targetGroupRulesData.([]interface{}) {
 			vMap := targetGroupRuleData.(map[string]interface{})
 			targetGroupRule := TargetGroupRules{
-				Kind:      AddRule,
-				GroupName: vMap[GroupName].(string),
-				Variation: vMap[VariationVar].(string),
+				Kind:      aws.String(AddRule),
+				GroupName: aws.String(vMap[GroupName].(string)),
+				Variation: aws.String(vMap[VariationVar].(string)),
 			}
 
 			var distribution *Distribution = nil
@@ -592,23 +592,23 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 				for _, distributionData := range distrib.([]interface{}) {
 					vMap := distributionData.(map[string]interface{})
 					distribution = &Distribution{
-						BuckedBy: BuckedBy,
+						BuckedBy: aws.String(BuckedBy),
 					}
-					var variations []Variation
+					var variations []*Variation
 					for _, variationData := range vMap["variations"].([]interface{}) {
 						vMap := variationData.(map[string]interface{})
-						variation := Variation{
-							Variation: vMap[VariationVar].(string),
-							Weight:    vMap[Weight].(int),
+						variation := &Variation{
+							Variation: aws.String(vMap[VariationVar].(string)),
+							Weight:    aws.Int(vMap[Weight].(int)),
 						}
 						variations = append(variations, variation)
 					}
 					distribution.Variations = variations
 				}
 			}
-			instruction := Instruction{
+			instruction := &Instruction{
 				Kind: targetGroupRule.Kind,
-				Parameters: Parameter{
+				Parameters: &Parameter{
 					Serve: &Serve{
 						Variation:    targetGroupRule.Variation,
 						Distribution: distribution,
@@ -616,7 +616,7 @@ func buildFFPatchOpts(d *schema.ResourceData) *nextgen.FeatureFlagsApiPatchFeatu
 					Clauses: []*nextgen.Clause{
 						{
 							Op:     SegmentMatch,
-							Values: []string{targetGroupRule.GroupName},
+							Values: []string{aws.StringValue(targetGroupRule.GroupName)},
 						},
 					},
 				},

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -339,13 +339,21 @@ func resourceFeatureFlagUpdate(ctx context.Context, d *schema.ResourceData, meta
 	qp := buildFFQueryParameters(d)
 	opts := buildFFPatchOpts(d)
 
-	feature, httpResp, err := c.FeatureFlagsApi.PatchFeature(ctx, c.AccountId, qp.OrganizationId, qp.ProjectId, id, opts)
+	_, httpResp, err := c.FeatureFlagsApi.PatchFeature(ctx, c.AccountId, qp.OrganizationId, qp.ProjectId, id, opts)
 
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)
 	}
 
-	readFeatureFlag(d, &feature, qp)
+	readOpts := buildFFReadOpts(d)
+
+	resp, httpResp, err := c.FeatureFlagsApi.GetFeatureFlag(ctx, id, c.AccountId, qp.OrganizationId, qp.ProjectId, readOpts)
+
+	if err != nil {
+		return helpers.HandleApiError(err, d, httpResp)
+	}
+
+	readFeatureFlag(d, &resp, qp)
 
 	return nil
 }

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -145,13 +145,11 @@ func ResourceFeatureFlag() *schema.Resource {
 							Description: "The identifier of the variation. Valid values are `enabled`, `disabled`",
 							Type:        schema.TypeString,
 							Optional:    true,
-							Computed:    true,
 						},
 						"targets": {
 							Description: "The targets of the rule",
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							MinItems:    0,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
@@ -171,39 +169,33 @@ func ResourceFeatureFlag() *schema.Resource {
 							Description: "The name of the target group",
 							Type:        schema.TypeString,
 							Optional:    true,
-							Computed:    true,
 						},
 						"variation": {
 							Description: "The identifier of the variation. Valid values are `enabled`, `disabled`",
 							Type:        schema.TypeString,
 							Optional:    true,
-							Computed:    true,
 						},
 						"distribution": {
 							Description: "The distribution of the rule",
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"variations": {
 										Description: "The variations of the rule",
 										Type:        schema.TypeList,
 										Optional:    true,
-										Computed:    true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"variation": {
 													Description: "The identifier of the variation",
 													Type:        schema.TypeString,
 													Optional:    true,
-													Computed:    true,
 												},
 												"weight": {
 													Description: "The weight of the variation",
 													Type:        schema.TypeInt,
 													Optional:    true,
-													Computed:    true,
 												},
 											},
 										},

--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -93,6 +93,7 @@ func ResourceFeatureFlag() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 			},
 			"permanent": {
 				Description: "Whether or not the flag is permanent. If it is, it will never be flagged as stale",
@@ -140,17 +141,20 @@ func ResourceFeatureFlag() *schema.Resource {
 				Description: "The targeting rules for the flag",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"variation": {
 							Description: "The identifier of the variation. Valid values are `enabled`, `disabled`",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"targets": {
 							Description: "The targets of the rule",
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							MinItems:    0,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
@@ -163,39 +167,46 @@ func ResourceFeatureFlag() *schema.Resource {
 				Description: "The targeting rules for the flag",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group_name": {
 							Description: "The name of the target group",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"variation": {
 							Description: "The identifier of the variation. Valid values are `enabled`, `disabled`",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"distribution": {
 							Description: "The distribution of the rule",
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"variations": {
 										Description: "The variations of the rule",
 										Type:        schema.TypeList,
 										Optional:    true,
+										Computed:    true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"variation": {
 													Description: "The identifier of the variation",
 													Type:        schema.TypeString,
 													Optional:    true,
+													Computed:    true,
 												},
 												"weight": {
 													Description: "The weight of the variation",
 													Type:        schema.TypeInt,
 													Optional:    true,
+													Computed:    true,
 												},
 											},
 										},

--- a/internal/service/platform/feature_flag_target/resource_feature_flag_target.go
+++ b/internal/service/platform/feature_flag_target/resource_feature_flag_target.go
@@ -21,7 +21,7 @@ func ResourceFeatureFlagTarget() *schema.Resource {
 		ReadContext:   resourceFeatureFlagTargetRead,
 		DeleteContext: resourceFeatureFlagTargetDelete,
 		CreateContext: resourceFeatureFlagTargetCreateOrUpdate,
-		UpdateContext: resourceFeatureFlagTargetUpdate,
+		UpdateContext: resourceFeatureFlagTargetCreateOrUpdate,
 		Importer:      helpers.ProjectResourceImporter,
 
 		Schema: map[string]*schema.Schema{
@@ -65,6 +65,7 @@ func ResourceFeatureFlagTarget() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
+++ b/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/antihax/optional"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
 	"github.com/harness/terraform-provider-harness/helpers"
 	"github.com/harness/terraform-provider-harness/internal"
@@ -66,6 +67,7 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				MinItems:    0,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -76,6 +78,7 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				MinItems:    0,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -93,24 +96,28 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
+							ForceNew:    true,
 						},
 						"negate": {
 							Description: "Is the operation negated?",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Computed:    true,
+							ForceNew:    true,
 						},
 						"op": {
 							Description: "The type of operation such as equals, starts_with, contains",
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
+							ForceNew:    true,
 						},
 						"values": {
 							Description: "The values that are compared against the operator",
 							Type:        schema.TypeList,
 							Optional:    true,
 							Computed:    true,
+							ForceNew:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -135,22 +142,22 @@ type FFTargetGroupQueryParameters struct {
 
 // FFTargetGroupOpts ...
 type FFTargetGroupOpts struct {
-	Identifier string           `json:"identifier,omitempty"`
-	Name       string           `json:"name,omitempty"`
-	Included   []string         `json:"included,omitempty"`
-	Excluded   []string         `json:"excluded,omitempty"`
-	Rules      []nextgen.Clause `json:"rules,omitempty"`
+	Identifier string            `json:"identifier,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Included   []*string         `json:"included,omitempty"`
+	Excluded   []*string         `json:"excluded,omitempty"`
+	Rules      []*nextgen.Clause `json:"rules,omitempty"`
 }
 
 // SegmentRequest ...
 type SegmentRequest struct {
-	Identifier  string           `json:"identifier,omitempty"`
-	Project     string           `json:"project,omitempty"`
-	Environment string           `json:"environment,omitempty"`
-	Name        string           `json:"name,omitempty"`
-	Included    []string         `json:"included,omitempty"`
-	Excluded    []string         `json:"excluded,omitempty"`
-	Rules       []nextgen.Clause `json:"rules,omitempty"`
+	Identifier  string            `json:"identifier,omitempty"`
+	Project     string            `json:"project,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Included    []*string         `json:"included,omitempty"`
+	Excluded    []*string         `json:"excluded,omitempty"`
+	Rules       []*nextgen.Clause `json:"rules,omitempty"`
 }
 
 func resourceFeatureFlagTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -294,29 +301,29 @@ func buildSegmentRequest(d *schema.ResourceData) *SegmentRequest {
 	}
 
 	if included, ok := d.GetOk("included"); ok {
-		var targets []string = make([]string, 0)
+		var targets = make([]*string, 0)
 		for _, target := range included.([]interface{}) {
-			targets = append(targets, target.(string))
+			targets = append(targets, aws.String(target.(string)))
 		}
 		opts.Included = targets
 	}
 
 	if excluded, ok := d.GetOk("excluded"); ok {
-		var targets []string = make([]string, 0)
+		var targets = make([]*string, 0)
 		for _, target := range excluded.([]interface{}) {
-			targets = append(targets, target.(string))
+			targets = append(targets, aws.String(target.(string)))
 		}
 		opts.Excluded = targets
 	}
 
 	if rules, ok := d.GetOk("rule"); ok {
-		var rulesList = make([]nextgen.Clause, 0)
+		var rulesList = make([]*nextgen.Clause, 0)
 		for _, rule := range rules.([]interface{}) {
 			var values []string
 			for _, value := range rule.(map[string]interface{})["values"].([]interface{}) {
 				values = append(values, value.(string))
 			}
-			rule := nextgen.Clause{
+			rule := &nextgen.Clause{
 				Attribute: rule.(map[string]interface{})["attribute"].(string),
 				Negate:    rule.(map[string]interface{})["negate"].(bool),
 				Op:        rule.(map[string]interface{})["op"].(string),
@@ -338,29 +345,29 @@ func buildFFTargetGroupOpts(d *schema.ResourceData) *nextgen.TargetGroupsApiPatc
 	}
 
 	if included, ok := d.GetOk("included"); ok {
-		var targets []string = make([]string, 0)
+		var targets = make([]*string, 0)
 		for _, target := range included.([]interface{}) {
-			targets = append(targets, target.(string))
+			targets = append(targets, aws.String(target.(string)))
 		}
 		opts.Included = targets
 	}
 
 	if excluded, ok := d.GetOk("excluded"); ok {
-		var targets []string = make([]string, 0)
+		var targets = make([]*string, 0)
 		for _, target := range excluded.([]interface{}) {
-			targets = append(targets, target.(string))
+			targets = append(targets, aws.String(target.(string)))
 		}
 		opts.Excluded = targets
 	}
 
 	if rules, ok := d.GetOk("rule"); ok {
-		var rulesList = make([]nextgen.Clause, 0)
+		var rulesList = make([]*nextgen.Clause, 0)
 		for _, rule := range rules.([]interface{}) {
 			var values []string = make([]string, 0)
 			for _, value := range rule.(map[string]interface{})["values"].([]interface{}) {
 				values = append(values, value.(string))
 			}
-			rule := nextgen.Clause{
+			rule := &nextgen.Clause{
 				Attribute: rule.(map[string]interface{})["attribute"].(string),
 				Negate:    rule.(map[string]interface{})["negate"].(bool),
 				Op:        rule.(map[string]interface{})["op"].(string),

--- a/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
+++ b/internal/service/platform/feature_flag_target_group/resource_feature_flag_target_group.go
@@ -65,6 +65,7 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Description: "A list of targets to include in the target group",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MinItems:    0,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -74,6 +75,7 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Description: "A list of targets to exclude from the target group",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MinItems:    0,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -83,27 +85,32 @@ func ResourceFeatureFlagTargetGroup() *schema.Resource {
 				Description: "The list of rules used to include targets in the target group.",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attribute": {
 							Description: "The attribute to use in the clause.  This can be any target attribute",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"negate": {
 							Description: "Is the operation negated?",
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Computed:    true,
 						},
 						"op": {
 							Description: "The type of operation such as equals, starts_with, contains",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"values": {
 							Description: "The values that are compared against the operator",
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},


### PR DESCRIPTION
## Describe your changes
This change fixes updating and deleting targets and targets groups. It also allows for updating of rules with distributions (i.e 50% for enabled, 50% for disabled), with the weight values being allowed to change. However, there's an issue updating target rules, due to the way we are currently implementing "addRule" and "removeRule" as part of a JavaScript action in the UI that does not translate easily in terraform. 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
