### PR TITLE
feat: [CCM-11423] Support for import of AWS ALB and Azure AppGateway as AutoStopping Loadbalancer

### DIFF
--- a/internal/service/platform/autostopping/load_balancer/aws_alb.go
+++ b/internal/service/platform/autostopping/load_balancer/aws_alb.go
@@ -75,6 +75,9 @@ func ResourceAwsALB() *schema.Resource {
 
 func resourceAwsALBCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	lb := buildLoadBalancer(d, c.AccountId, "aws", "")
+	lb, err := buildLoadBalancer(d, c.AccountId, "aws", "")
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return resourceLoadBalancerCreateOrUpdate(ctx, d, meta, lb)
 }

--- a/internal/service/platform/autostopping/load_balancer/aws_proxy.go
+++ b/internal/service/platform/autostopping/load_balancer/aws_proxy.go
@@ -111,6 +111,9 @@ func ResourceAWSProxy() *schema.Resource {
 
 func resourceAWSProxyCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	lb := buildLoadBalancer(d, c.AccountId, "aws", "autostopping_proxy")
+	lb, err := buildLoadBalancer(d, c.AccountId, "aws", "autostopping_proxy")
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return resourceLoadBalancerCreateOrUpdate(ctx, d, meta, lb)
 }

--- a/internal/service/platform/autostopping/load_balancer/azure_gateway.go
+++ b/internal/service/platform/autostopping/load_balancer/azure_gateway.go
@@ -82,6 +82,9 @@ func ResourceAzureGateway() *schema.Resource {
 
 func resourceAzureGatewayCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	lb := buildLoadBalancer(d, c.AccountId, "azure", "app_gateway")
+	lb, err := buildLoadBalancer(d, c.AccountId, "azure", "app_gateway")
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return resourceLoadBalancerCreateOrUpdate(ctx, d, meta, lb)
 }

--- a/internal/service/platform/autostopping/load_balancer/azure_proxy.go
+++ b/internal/service/platform/autostopping/load_balancer/azure_proxy.go
@@ -121,6 +121,9 @@ func ResourceAzureProxy() *schema.Resource {
 
 func resourceAzureProxyCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	lb := buildLoadBalancer(d, c.AccountId, "azure", "autostopping_proxy")
+	lb, err := buildLoadBalancer(d, c.AccountId, "azure", "autostopping_proxy")
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return resourceLoadBalancerCreateOrUpdate(ctx, d, meta, lb)
 }

--- a/internal/service/platform/autostopping/load_balancer/gcp_proxy.go
+++ b/internal/service/platform/autostopping/load_balancer/gcp_proxy.go
@@ -111,6 +111,9 @@ func ResourceGCPProxy() *schema.Resource {
 
 func resourceGCPProxyCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	lb := buildLoadBalancer(d, c.AccountId, "gcp", "autostopping_proxy")
+	lb, err := buildLoadBalancer(d, c.AccountId, "gcp", "autostopping_proxy")
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return resourceLoadBalancerCreateOrUpdate(ctx, d, meta, lb)
 }


### PR DESCRIPTION
## Changes
Ticket : [CCM-CCM-11423](https://harness.atlassian.net/browse/CCM-11423)

* Support for import of ALB as AutoStopping Loadbalancer
* Support for import of AppGateway as AutoStopping Loadbalancer

### Missing support 
* Support for creating Azure AppGateway using certificate payload
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`