### PR TITLE
fix: [CCM-14715] Modified days attribute in fixed schedule of AutoStopping

### DIFF
--- a/.changelog/731.txt
+++ b/.changelog/731.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Days attribute of AutoStopping fixed schedule has been modified to be list of weekdays instead of string for brevity
+```

--- a/docs/data-sources/autostopping_schedule.md
+++ b/docs/data-sources/autostopping_schedule.md
@@ -35,6 +35,6 @@ Data source for retrieving a fixed schedule for Harness AutoStopping rule
 
 Read-Only:
 
-- `days` (String)
+- `days` (List of String)
 - `end_time` (String)
 - `start_time` (String)

--- a/docs/resources/autostopping_schedule.md
+++ b/docs/resources/autostopping_schedule.md
@@ -19,7 +19,7 @@ resource "harness_autostopping_schedule" "MondayWholeDayUp" {
   time_zone     = "UTC"
 
   repeats {
-    days = "MON"
+    days = ["MON"]
   }
 
   rules = [123]
@@ -31,7 +31,7 @@ resource "harness_autostopping_schedule" "MondayUpTill4:30pm" {
   time_zone     = "UTC"
 
   repeats {
-    days     = "MON"
+    days     = ["MON"]
     end_time = "16:30"
   }
 
@@ -44,7 +44,7 @@ resource "harness_autostopping_schedule" "MondayThroughFridayUptimeFrom9amTo6pm"
   time_zone     = "UTC"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "09:00"
     end_time   = "18:00"
   }
@@ -60,7 +60,7 @@ resource "harness_autostopping_schedule" "MondayThroughFridayUptimeFrom9amTo6pmS
   starting_from = "2023-01-02 15:04:05"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "09:00"
     end_time   = "18:00"
   }
@@ -77,7 +77,7 @@ resource "harness_autostopping_schedule" "DownTimeForISTLuchOnEveryFridayInBetwe
   ending_on     = "2023-02-02 15:04:05"
 
   repeats {
-    days       = "FRI"
+    days       = ["FRI"]
     start_time = "12:30"
     end_time   = "14:30"
   }
@@ -91,7 +91,7 @@ resource "harness_autostopping_schedule" "DowntimeEveryFridayAfterNoonTillEOD" {
   time_zone     = "Asia/Calcutta"
 
   repeats {
-    days       = "FRI"
+    days       = ["FRI"]
     start_time = "17:30"
   }
 
@@ -104,7 +104,7 @@ resource "harness_autostopping_schedule" "CompleteDownTimeOnWeekEnd" {
   time_zone     = "UTC"
 
   repeats {
-    days = "SUN, SAT"
+    days = ["SUN", "SAT"]
   }
 
   rules = [123]
@@ -126,7 +126,7 @@ resource "harness_autostopping_schedule" "OverNightDowntimeOnWeekDays" {
   time_zone     = "Asia/Calcutta"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "18:00"
     end_time   = "07:00"
   }
@@ -161,7 +161,7 @@ resource "harness_autostopping_schedule" "OverNightDowntimeOnWeekDays" {
 
 Required:
 
-- `days` (String) Days on which schedule need to be active. Comma separated values of `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`. Eg : `MON,TUE,WED,THU,FRI` for Mon through Friday
+- `days` (List of String) List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.
 
 Optional:
 

--- a/docs/resources/autostopping_schedule.md
+++ b/docs/resources/autostopping_schedule.md
@@ -161,7 +161,7 @@ resource "harness_autostopping_schedule" "OverNightDowntimeOnWeekDays" {
 
 Required:
 
-- `days` (List of String) List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.
+- `days` (List of String) List of days on which schedule need to be active. Valid values are SUN, MON, TUE, WED, THU, FRI and SAT.
 
 Optional:
 

--- a/examples/resources/harness_autostopping_schedule/resource.tf
+++ b/examples/resources/harness_autostopping_schedule/resource.tf
@@ -4,7 +4,7 @@ resource "harness_autostopping_schedule" "MondayWholeDayUp" {
   time_zone     = "UTC"
 
   repeats {
-    days = "MON"
+    days = ["MON"]
   }
 
   rules = [123]
@@ -16,7 +16,7 @@ resource "harness_autostopping_schedule" "MondayUpTill4:30pm" {
   time_zone     = "UTC"
 
   repeats {
-    days     = "MON"
+    days     = ["MON"]
     end_time = "16:30"
   }
 
@@ -29,7 +29,7 @@ resource "harness_autostopping_schedule" "MondayThroughFridayUptimeFrom9amTo6pm"
   time_zone     = "UTC"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "09:00"
     end_time   = "18:00"
   }
@@ -45,7 +45,7 @@ resource "harness_autostopping_schedule" "MondayThroughFridayUptimeFrom9amTo6pmS
   starting_from = "2023-01-02 15:04:05"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "09:00"
     end_time   = "18:00"
   }
@@ -62,7 +62,7 @@ resource "harness_autostopping_schedule" "DownTimeForISTLuchOnEveryFridayInBetwe
   ending_on     = "2023-02-02 15:04:05"
 
   repeats {
-    days       = "FRI"
+    days       = ["FRI"]
     start_time = "12:30"
     end_time   = "14:30"
   }
@@ -76,7 +76,7 @@ resource "harness_autostopping_schedule" "DowntimeEveryFridayAfterNoonTillEOD" {
   time_zone     = "Asia/Calcutta"
 
   repeats {
-    days       = "FRI"
+    days       = ["FRI"]
     start_time = "17:30"
   }
 
@@ -89,7 +89,7 @@ resource "harness_autostopping_schedule" "CompleteDownTimeOnWeekEnd" {
   time_zone     = "UTC"
 
   repeats {
-    days = "SUN, SAT"
+    days = ["SUN", "SAT"]
   }
 
   rules = [123]
@@ -111,7 +111,7 @@ resource "harness_autostopping_schedule" "OverNightDowntimeOnWeekDays" {
   time_zone     = "Asia/Calcutta"
 
   repeats {
-    days       = "MON, TUE, WED, THU, FRI"
+    days       = ["MON", "TUE", "WED", "THU", "FRI"]
     start_time = "18:00"
     end_time   = "07:00"
   }

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -234,17 +234,24 @@ func timeValidation(i interface{}, p cty.Path) diag.Diagnostics {
 
 func daysValidationFunc(i interface{}, p cty.Path) diag.Diagnostics {
 	diags := diag.Diagnostics{}
-	v, ok := i.(string)
+	daysInf, ok := i.([]interface{})
 	if !ok {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Value is mandatory and should be string",
+			Summary:  "Days should be specified for repetition",
 		})
 		return diags
 	}
-	parts := strings.Split(v, ",")
 	unique := map[string]struct{}{}
-	for _, p := range parts {
+	for _, dayInf := range daysInf {
+		p, ok := dayInf.(string)
+		if !ok {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Days should be specified for repetition",
+			})
+			continue
+		}
 		vp := strings.TrimSpace(p)
 		if _, checked := unique[vp]; checked {
 			diags = append(diags, diag.Diagnostic{
@@ -261,11 +268,11 @@ func daysValidationFunc(i interface{}, p cty.Path) diag.Diagnostics {
 		if !match {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  "Valid input is comma separated values of `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`. Eg : `MON,TUE,WED,THU,FRI` for Mon through Friday ",
+				Summary:  "Valid input is list of `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
 			})
 		}
 	}
-	if len(parts) < 1 || len(parts) > 7 {
+	if len(daysInf) < 1 || len(daysInf) > 7 {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "At-least one and at-most seven days can be specified",

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -127,10 +127,13 @@ func ResourceVMRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						daysAttribute: {
-							Description:      "Days on which schedule need to be active. Comma separated values of `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`. Eg : `MON,TUE,WED,THU,FRI` for Mon through Friday",
+							Description:      "List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateDiagFunc: daysValidationFunc,
+							Elem: schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 						startTimeAttribute: {
 							Description:      "Starting time of schedule action on the day. Defaults to 00:00Hrs unless specified. Accepted format is HH:MM. Eg : 13:15 for 01:15pm",

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -128,9 +128,9 @@ func ResourceVMRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						daysAttribute: {
 							Description:      "List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
-							Type:             schema.TypeString,
 							Required:         true,
 							ValidateDiagFunc: daysValidationFunc,
+							Type:             schema.TypeList,
 							Elem: schema.Schema{
 								Type: schema.TypeString,
 							},

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -505,7 +505,7 @@ func setSchedule(d *schema.ResourceData, schedule *nextgen.FixedSchedule) diag.D
 	}
 	identifier := strconv.Itoa(int(schedule.Id))
 	d.SetId(identifier)
-	d.Set("identifier", identifier)
+	d.Set("identifier", float64(schedule.Id))
 	d.Set(nameAttribute, schedule.Name)
 	scheduleType := uptimeSchedule
 	schedDet := schedule.Details.Uptime

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -373,14 +373,16 @@ func parseSchedule(d *schema.ResourceData, accountId string) (*nextgen.FixedSche
 				days := []float64{}
 				daysInf, ok := periodicityObj[daysAttribute]
 				if ok {
-					daysCsv, ok := daysInf.(string)
+					daysInf, ok := daysInf.([]interface{})
 					if ok {
-						dayParts := strings.Split(daysCsv, ",")
-						for _, dp := range dayParts {
-							dv := strings.TrimSpace(dp)
-							i, ok := dayIndex[strings.ToUpper(dv)]
+						for _, dayInf := range daysInf {
+							dp, ok := dayInf.(string)
 							if ok {
-								days = append(days, float64(i))
+								dv := strings.TrimSpace(dp)
+								i, ok := dayIndex[strings.ToUpper(dv)]
+								if ok {
+									days = append(days, float64(i))
+								}
 							}
 						}
 					}

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -550,7 +550,7 @@ func setSchedule(d *schema.ResourceData, schedule *nextgen.FixedSchedule) diag.D
 				periodicity[endTimeAttribute] = endTime
 			}
 		}
-		d.Set(repetitionAttribute, periodicity)
+		d.Set(repetitionAttribute, []interface{}{periodicity})
 	}
 	return diags
 }

--- a/internal/service/platform/autostopping/schedule/schedule.go
+++ b/internal/service/platform/autostopping/schedule/schedule.go
@@ -131,7 +131,9 @@ func ResourceVMRule() *schema.Resource {
 							Required:         true,
 							ValidateDiagFunc: daysValidationFunc,
 							Type:             schema.TypeList,
-							Elem: schema.Schema{
+							MinItems:         1,
+							MaxItems:         7,
+							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
 						},

--- a/internal/service/platform/autostopping/schedule/schedule_data_source.go
+++ b/internal/service/platform/autostopping/schedule/schedule_data_source.go
@@ -48,7 +48,7 @@ func DataSourceFixedSchedule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						daysAttribute: {
-							Description: "List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
+							Description: "List of days on which schedule need to be active. Valid values are SUN, MON, TUE, WED, THU, FRI and SAT.",
 							Type:        schema.TypeList,
 							Computed:    true,
 							Elem: &schema.Schema{

--- a/internal/service/platform/autostopping/schedule/schedule_data_source.go
+++ b/internal/service/platform/autostopping/schedule/schedule_data_source.go
@@ -51,7 +51,7 @@ func DataSourceFixedSchedule() *schema.Resource {
 							Description: "List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
 							Type:        schema.TypeList,
 							Computed:    true,
-							Elem: schema.Schema{
+							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
 						},

--- a/internal/service/platform/autostopping/schedule/schedule_data_source.go
+++ b/internal/service/platform/autostopping/schedule/schedule_data_source.go
@@ -48,9 +48,12 @@ func DataSourceFixedSchedule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						daysAttribute: {
-							Description: "Days on which schedule need to be active. Comma separated values of `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`. Eg : `MON,TUE,WED,THU,FRI` for Mon through Friday",
-							Type:        schema.TypeString,
+							Description: "List of days on which schedule need to be active. Valid values are `SUN`, `MON`, `TUE`, `WED`, `THU`, `FRI` and `SAT`.",
+							Type:        schema.TypeList,
 							Computed:    true,
+							Elem: schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 						startTimeAttribute: {
 							Description: "Starting time of schedule action on the day. Accepted format is HH:MM. Eg : 13:15 for 01:15pm",

--- a/internal/service/platform/autostopping/schedule/schedule_test.go
+++ b/internal/service/platform/autostopping/schedule/schedule_test.go
@@ -39,7 +39,7 @@ func testSchedule(name string) string {
 		}
 	
 		periodicity {
-			days = "MON, THU, TUE"
+			days = ["MON", "THU", "TUE"]
 			start_time = "09:30"
 			end_time = "16:50"
 		}


### PR DESCRIPTION
## Modified days attribute in fixed schedule of AutoStopping

[Design Doc](https://harness.atlassian.net/wiki/spaces/LWG/pages/21535326993/Terraform+Support+for+Fixed+Schedules)

Type of days attribute in fixed schedule of AutoStopping was string where comma separated values of week day was expected. It has been modified to take list of weekdays for brevity
