### PR TITLE
fix: [CDS-82953]: Add force delete option for aws, azure, gcp, k8s, rancher, oci and helm connectors

### DIFF
--- a/.changelog/743.txt
+++ b/.changelog/743.txt
@@ -1,0 +1,9 @@
+```release-note:enhancement
+resource/platform_connector_aws: added force deletion support
+resource/platform_connector_azure_cloud_provider: added force deletion support
+resources/platform_connector_gcp: added force deletion support
+resources/platform_connector_helm: added force deletion support
+resources/platform_connector_kubernetes: added force deletion support
+resources/platform_connector_oci_helm: added force deletion support
+resources/platform_connector_rancher: added force deletion support
+```

--- a/docs/resources/platform_connector_aws.md
+++ b/docs/resources/platform_connector_aws.md
@@ -102,7 +102,7 @@ resource "harness_platform_connector_aws" "aws" {
 - `description` (String) Description of the resource.
 - `equal_jitter_backoff_strategy` (Block List, Max: 1) Equal Jitter BackOff Strategy. (see [below for nested schema](#nestedblock--equal_jitter_backoff_strategy))
 - `fixed_delay_backoff_strategy` (Block List, Max: 1) Fixed Delay BackOff Strategy. (see [below for nested schema](#nestedblock--fixed_delay_backoff_strategy))
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `full_jitter_backoff_strategy` (Block List, Max: 1) Full Jitter BackOff Strategy. (see [below for nested schema](#nestedblock--full_jitter_backoff_strategy))
 - `inherit_from_delegate` (Block List, Max: 1) Inherit credentials from the delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `irsa` (Block List, Max: 1) Use IAM role for service accounts. (see [below for nested schema](#nestedblock--irsa))

--- a/docs/resources/platform_connector_aws.md
+++ b/docs/resources/platform_connector_aws.md
@@ -102,6 +102,7 @@ resource "harness_platform_connector_aws" "aws" {
 - `description` (String) Description of the resource.
 - `equal_jitter_backoff_strategy` (Block List, Max: 1) Equal Jitter BackOff Strategy. (see [below for nested schema](#nestedblock--equal_jitter_backoff_strategy))
 - `fixed_delay_backoff_strategy` (Block List, Max: 1) Fixed Delay BackOff Strategy. (see [below for nested schema](#nestedblock--fixed_delay_backoff_strategy))
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `full_jitter_backoff_strategy` (Block List, Max: 1) Full Jitter BackOff Strategy. (see [below for nested schema](#nestedblock--full_jitter_backoff_strategy))
 - `inherit_from_delegate` (Block List, Max: 1) Inherit credentials from the delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `irsa` (Block List, Max: 1) Use IAM role for service accounts. (see [below for nested schema](#nestedblock--irsa))

--- a/docs/resources/platform_connector_azure_cloud_provider.md
+++ b/docs/resources/platform_connector_azure_cloud_provider.md
@@ -118,7 +118,7 @@ resource "harness_platform_connector_azure_cloud_provider" "inherit_from_delegat
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
 - `execute_on_delegate` (Boolean) Execute on delegate or not.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_azure_cloud_provider.md
+++ b/docs/resources/platform_connector_azure_cloud_provider.md
@@ -118,6 +118,7 @@ resource "harness_platform_connector_azure_cloud_provider" "inherit_from_delegat
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
 - `execute_on_delegate` (Boolean) Execute on delegate or not.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_gcp.md
+++ b/docs/resources/platform_connector_gcp.md
@@ -50,7 +50,7 @@ resource "harness_platform_connector_gcp" "test" {
 ### Optional
 
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `inherit_from_delegate` (Block List) Inherit configuration from delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `manual` (Block List, Max: 1) Manual credential configuration. (see [below for nested schema](#nestedblock--manual))
 - `org_id` (String) Unique identifier of the organization.

--- a/docs/resources/platform_connector_gcp.md
+++ b/docs/resources/platform_connector_gcp.md
@@ -50,6 +50,7 @@ resource "harness_platform_connector_gcp" "test" {
 ### Optional
 
 - `description` (String) Description of the resource.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `inherit_from_delegate` (Block List) Inherit configuration from delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `manual` (Block List, Max: 1) Manual credential configuration. (see [below for nested schema](#nestedblock--manual))
 - `org_id` (String) Unique identifier of the organization.

--- a/docs/resources/platform_connector_helm.md
+++ b/docs/resources/platform_connector_helm.md
@@ -54,7 +54,7 @@ resource "harness_platform_connector_helm" "test" {
 - `credentials` (Block List, Max: 1) Credentials to use for authentication. (see [below for nested schema](#nestedblock--credentials))
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_helm.md
+++ b/docs/resources/platform_connector_helm.md
@@ -54,6 +54,7 @@ resource "harness_platform_connector_helm" "test" {
 - `credentials` (Block List, Max: 1) Credentials to use for authentication. (see [below for nested schema](#nestedblock--credentials))
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_kubernetes.md
+++ b/docs/resources/platform_connector_kubernetes.md
@@ -106,6 +106,7 @@ resource "harness_platform_connector_kubernetes" "inheritFromDelegate" {
 - `client_key_cert` (Block List, Max: 1) Client key and certificate config for the connector. (see [below for nested schema](#nestedblock--client_key_cert))
 - `delegate_selectors` (Set of String) Selectors to use for the delegate.
 - `description` (String) Description of the resource.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `inherit_from_delegate` (Block List, Max: 1) Credentials are inherited from the delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `openid_connect` (Block List, Max: 1) OpenID configuration for the connector. (see [below for nested schema](#nestedblock--openid_connect))
 - `org_id` (String) Unique identifier of the organization.

--- a/docs/resources/platform_connector_kubernetes.md
+++ b/docs/resources/platform_connector_kubernetes.md
@@ -106,7 +106,7 @@ resource "harness_platform_connector_kubernetes" "inheritFromDelegate" {
 - `client_key_cert` (Block List, Max: 1) Client key and certificate config for the connector. (see [below for nested schema](#nestedblock--client_key_cert))
 - `delegate_selectors` (Set of String) Selectors to use for the delegate.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `inherit_from_delegate` (Block List, Max: 1) Credentials are inherited from the delegate. (see [below for nested schema](#nestedblock--inherit_from_delegate))
 - `openid_connect` (Block List, Max: 1) OpenID configuration for the connector. (see [below for nested schema](#nestedblock--openid_connect))
 - `org_id` (String) Unique identifier of the organization.

--- a/docs/resources/platform_connector_oci_helm.md
+++ b/docs/resources/platform_connector_oci_helm.md
@@ -54,6 +54,7 @@ resource "harness_platform_connector_oci_helm" "test" {
 - `credentials` (Block List, Max: 1) Credentials to use for authentication. (see [below for nested schema](#nestedblock--credentials))
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_oci_helm.md
+++ b/docs/resources/platform_connector_oci_helm.md
@@ -54,7 +54,7 @@ resource "harness_platform_connector_oci_helm" "test" {
 - `credentials` (Block List, Max: 1) Credentials to use for authentication. (see [below for nested schema](#nestedblock--credentials))
 - `delegate_selectors` (Set of String) Tags to filter delegates for connection.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_rancher.md
+++ b/docs/resources/platform_connector_rancher.md
@@ -41,7 +41,7 @@ resource "harness_platform_connector_kubernetes" "bearer_token" {
 - `bearer_token` (Block List, Max: 1) Bearer token information for the rancher cluster. (see [below for nested schema](#nestedblock--bearer_token))
 - `delegate_selectors` (Set of String) Selectors to use for the delegate.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of connector
+- `force_delete` (Boolean) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_connector_rancher.md
+++ b/docs/resources/platform_connector_rancher.md
@@ -41,6 +41,7 @@ resource "harness_platform_connector_kubernetes" "bearer_token" {
 - `bearer_token` (Block List, Max: 1) Bearer token information for the rancher cluster. (see [below for nested schema](#nestedblock--bearer_token))
 - `delegate_selectors` (Set of String) Selectors to use for the delegate.
 - `description` (String) Description of the resource.
+- `force_delete` (String) Enable this flag for force deletion of connector
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.46.4
 	github.com/docker/docker v24.0.5+incompatible
-	github.com/harness/harness-go-sdk v0.3.58
+	github.com/harness/harness-go-sdk v0.3.59
 	github.com/harness/harness-openapi-go-client v0.0.19
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/harness/harness-go-sdk v0.3.58 h1:urTdoLM3zmsC8o7TgoZ47aU2rlSpRhO/mW+qDalRKe4=
-github.com/harness/harness-go-sdk v0.3.58/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
+github.com/harness/harness-go-sdk v0.3.59 h1:l2aDHzLiWdHy48onBE5iZeclEYMPtHhlsz8iAtgreBg=
+github.com/harness/harness-go-sdk v0.3.59/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
 github.com/harness/harness-openapi-go-client v0.0.19 h1:8XuZvSPZrNqKRLh7Qksdz78WvRMRzRf88LgzxoT5u7k=
 github.com/harness/harness-openapi-go-client v0.0.19/go.mod h1:u0vqYb994BJGotmEwJevF4L3BNAdU9i8ui2d22gmLPA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/helpers/schema.go
+++ b/helpers/schema.go
@@ -177,6 +177,14 @@ func BuildFieldForBoolean(d *schema.ResourceData, field string) optional.Bool {
 	return optional.EmptyBool()
 }
 
+func BuildFieldBool(d *schema.ResourceData, field string) optional.Bool {
+	if b, ok := d.GetOk(field); ok {
+		return optional.NewBool(b.(bool))
+	}
+
+	return optional.EmptyBool()
+}
+
 // PipelineResourceImporter defines the importer configuration for all pipeline level resources.
 var PipelineResourceImporter = &schema.ResourceImporter{
 	State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/internal/service/platform/connector/aws.go
+++ b/internal/service/platform/connector/aws.go
@@ -219,7 +219,7 @@ func ResourceConnectorAws() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/aws.go
+++ b/internal/service/platform/connector/aws.go
@@ -217,6 +217,12 @@ func ResourceConnectorAws() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/aws_test.go
+++ b/internal/service/platform/connector/aws_test.go
@@ -215,6 +215,39 @@ func TestAccResourceConnectorAws_Manual_Full_Jitter(t *testing.T) {
 	})
 }
 
+func TestAccResourceConnectorAws_ForceDelete(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	resourceName := "harness_platform_connector_aws.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnectorAws_force_delete(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inherit_from_delegate.0.delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorAws_inherit(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_connector_aws" "test" {
@@ -391,6 +424,23 @@ func testAccResourceConnectorAws_manual_fixed_delay(id string, name string) stri
 		resource "time_sleep" "wait_4_seconds" {
 			depends_on = [harness_platform_secret_text.test]
 			destroy_duration = "4s"
+		}
+`, id, name)
+}
+
+func testAccResourceConnectorAws_force_delete(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_connector_aws" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			inherit_from_delegate {
+				delegate_selectors = ["harness-delegate"]
+			}
+
+			force_delete = true
 		}
 `, id, name)
 }

--- a/internal/service/platform/connector/azure_cloud_provider.go
+++ b/internal/service/platform/connector/azure_cloud_provider.go
@@ -168,7 +168,7 @@ func ResourceConnectorAzureCloudProvider() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/azure_cloud_provider.go
+++ b/internal/service/platform/connector/azure_cloud_provider.go
@@ -166,6 +166,12 @@ func ResourceConnectorAzureCloudProvider() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/connector.go
+++ b/internal/service/platform/connector/connector.go
@@ -110,7 +110,7 @@ func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta i
 	_, httpResp, err := c.ConnectorsApi.DeleteConnector(ctx, c.AccountId, d.Id(), &nextgen.ConnectorsApiDeleteConnectorOpts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
-		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete")})
+		ForceDelete:       helpers.BuildFieldBool(d, "force_delete")})
 
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)

--- a/internal/service/platform/connector/connector.go
+++ b/internal/service/platform/connector/connector.go
@@ -109,7 +109,8 @@ func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, httpResp, err := c.ConnectorsApi.DeleteConnector(ctx, c.AccountId, d.Id(), &nextgen.ConnectorsApiDeleteConnectorOpts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
-		ProjectIdentifier: helpers.BuildField(d, "project_id")})
+		ProjectIdentifier: helpers.BuildField(d, "project_id"),
+		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete")})
 
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)

--- a/internal/service/platform/connector/gcp.go
+++ b/internal/service/platform/connector/gcp.go
@@ -69,7 +69,7 @@ func ResourceConnectorGcp() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/gcp.go
+++ b/internal/service/platform/connector/gcp.go
@@ -67,6 +67,12 @@ func ResourceConnectorGcp() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/gcp_test.go
+++ b/internal/service/platform/connector/gcp_test.go
@@ -74,6 +74,39 @@ func TestAccResourceConnectorGcp_Manual(t *testing.T) {
 	})
 }
 
+func TestAccResourceConnectorGcp_ForceDelete(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	resourceName := "harness_platform_connector_gcp.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnectorGcp_force_delete(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inherit_from_delegate.0.delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorGcp_inherit(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_connector_gcp" "test" {
@@ -118,6 +151,23 @@ func testAccResourceConnectorGcp_manual(id string, name string) string {
 		resource "time_sleep" "wait_4_seconds" {
 			depends_on = [harness_platform_secret_text.test]
 			destroy_duration = "4s"
+		}
+`, id, name)
+}
+
+func testAccResourceConnectorGcp_force_delete(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_connector_gcp" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			inherit_from_delegate {
+				delegate_selectors = ["harness-delegate"]
+			}
+
+			force_delete = true
 		}
 `, id, name)
 }

--- a/internal/service/platform/connector/http_helm.go
+++ b/internal/service/platform/connector/http_helm.go
@@ -61,6 +61,12 @@ func ResourceConnectorHelm() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/http_helm.go
+++ b/internal/service/platform/connector/http_helm.go
@@ -63,7 +63,7 @@ func ResourceConnectorHelm() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/http_helm_test.go
+++ b/internal/service/platform/connector/http_helm_test.go
@@ -90,6 +90,42 @@ func TestAccResourceConnector_httphelm_UsernamePassword(t *testing.T) {
 	})
 }
 
+func TestAccResourceConnectorAccountLevel_httphelm_ForceDelete(t *testing.T) {
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	resourceName := "harness_platform_connector_helm.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnector_httphelm_force_delete(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "https://helm.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+			},
+		},
+	})
+}
+
 func testAccResourceConnector_httphelm_usernamepassword(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -137,4 +173,18 @@ func testAccResourceConnector_httphelm_anonymous(id string, name string) string 
 			delegate_selectors = ["harness-delegate"]
 		}
 `, id, name)
+}
+
+func testAccResourceConnector_httphelm_force_delete(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_connector_helm" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			url = "https://helm.example.com"
+			delegate_selectors = ["harness-delegate"]
+			force_delete = true
+		}`, id, name)
 }

--- a/internal/service/platform/connector/k8s_cluster.go
+++ b/internal/service/platform/connector/k8s_cluster.go
@@ -275,7 +275,7 @@ func ResourceConnectorK8s() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/k8s_cluster.go
+++ b/internal/service/platform/connector/k8s_cluster.go
@@ -273,6 +273,12 @@ func ResourceConnectorK8s() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/k8s_rancher.go
+++ b/internal/service/platform/connector/k8s_rancher.go
@@ -52,7 +52,7 @@ func ResourceConnectorK8sRancher() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/k8s_rancher.go
+++ b/internal/service/platform/connector/k8s_rancher.go
@@ -50,6 +50,12 @@ func ResourceConnectorK8sRancher() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/k8s_rancher_test.go
+++ b/internal/service/platform/connector/k8s_rancher_test.go
@@ -58,6 +58,43 @@ func TestAccResourceConnectorRancher_BearerToken(t *testing.T) {
 	})
 }
 
+func TestAccResourceConnectorRancher_ForceDelete(t *testing.T) {
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	resourceName := "harness_platform_connector_rancher.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnectorRancher_ForceDelete(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rancher_url", "https://rancher.cluster.example"),
+					resource.TestCheckResourceAttr(resourceName, "bearer_token.0.bearer_token_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+			},
+		},
+	})
+}
+
 func testAccResourceConnectorRancher_BearerToken(id string, name string) string {
 	return fmt.Sprintf(`
 		resource "harness_platform_secret_text" "test" {
@@ -90,6 +127,37 @@ func testAccResourceConnectorRancher_BearerToken(id string, name string) string 
 		resource "time_sleep" "wait_4_seconds" {
 			depends_on = [harness_platform_secret_text.test]
 			destroy_duration = "4s"
+		}
+	`, id, name)
+}
+
+func testAccResourceConnectorRancher_ForceDelete(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_secret_text" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			secret_manager_identifier = "harnessSecretManager"
+			value_type = "Inline"
+			value = "secret"
+		}
+
+		resource "harness_platform_connector_rancher" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			delegate_selectors = ["harness-delegate"]
+			rancher_url = "https://rancher.cluster.example"
+
+			bearer_token {
+				bearer_token_ref = "account.${harness_platform_secret_text.test.id}"
+			}
+
+			force_delete = true
 		}
 	`, id, name)
 }

--- a/internal/service/platform/connector/oci_helm.go
+++ b/internal/service/platform/connector/oci_helm.go
@@ -61,6 +61,12 @@ func ResourceConnectorOciHelm() *schema.Resource {
 					},
 				},
 			},
+			"force_delete": {
+				Description: "Enable this flag for force deletion of connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 

--- a/internal/service/platform/connector/oci_helm.go
+++ b/internal/service/platform/connector/oci_helm.go
@@ -63,7 +63,7 @@ func ResourceConnectorOciHelm() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of connector",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/service/platform/connector/oci_helm_test.go
+++ b/internal/service/platform/connector/oci_helm_test.go
@@ -90,6 +90,43 @@ func TestAccResourceConnector_oci_helm_UsernamePassword(t *testing.T) {
 	})
 }
 
+func TestAccResourceConnector_oci_helm_ForceDelete(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	resourceName := "harness_platform_connector_oci_helm.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnector_oci_helm_force_delete(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "admin.azurecr.io"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+			},
+		},
+	})
+}
+
 func testAccResourceConnector_oci_helm_usernamepassword(id string, name string) string {
 	return fmt.Sprintf(`
 	resource "harness_platform_secret_text" "test" {
@@ -135,6 +172,21 @@ func testAccResourceConnector_oci_helm_anonymous(id string, name string) string 
 
 			url = "admin.azurecr.io"
 			delegate_selectors = ["harness-delegate"]
+		}
+`, id, name)
+}
+
+func testAccResourceConnector_oci_helm_force_delete(id string, name string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_connector_oci_helm" "test" {
+			identifier = "%[1]s"
+			name = "%[2]s"
+			description = "test"
+			tags = ["foo:bar"]
+
+			url = "admin.azurecr.io"
+			delegate_selectors = ["harness-delegate"]
+			force_delete = true
 		}
 `, id, name)
 }


### PR DESCRIPTION
## Describe your changes
This changes provide the force_delete option for next connectors:
- [x] GCP
- [x] AWS
- [x] Azure
- [x] Kubernetes
- [x] Rancher
- [x] Oci Helm
- [x] Http Helm

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
