### PR TITLE
[PL-42246] : Added more information in docs to have better clarity

### DIFF
--- a/docs/resources/platform_resource_group.md
+++ b/docs/resources/platform_resource_group.md
@@ -56,7 +56,7 @@ resource "harness_platform_resource_group" "test" {
 - `allowed_scope_levels` (Set of String) The scope levels at which this resource group can be used
 - `color` (String) Color of the environment.
 - `description` (String) Description of the resource.
-- `included_scopes` (Block Set) Included scopes; default chosen based on resource group scope if not specified. (see [below for nested schema](#nestedblock--included_scopes))
+- `included_scopes` (Block Set) Included scopes. The default is selected based on the resource group scope if not specified. (Go to [nested schema](#nestedblock--included_scopes) below.)
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `resource_filter` (Block List) Contains resource filter for a resource group (see [below for nested schema](#nestedblock--resource_filter))

--- a/docs/resources/platform_resource_group.md
+++ b/docs/resources/platform_resource_group.md
@@ -56,7 +56,7 @@ resource "harness_platform_resource_group" "test" {
 - `allowed_scope_levels` (Set of String) The scope levels at which this resource group can be used
 - `color` (String) Color of the environment.
 - `description` (String) Description of the resource.
-- `included_scopes` (Block Set) Included scopes (see [below for nested schema](#nestedblock--included_scopes))
+- `included_scopes` (Block Set) Included scopes; default chosen based on resource group scope if not specified. (see [below for nested schema](#nestedblock--included_scopes))
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `resource_filter` (Block List) Contains resource filter for a resource group (see [below for nested schema](#nestedblock--resource_filter))

--- a/internal/service/platform/resource_group/resource_group.go
+++ b/internal/service/platform/resource_group/resource_group.go
@@ -44,7 +44,7 @@ func ResourceResourceGroup() *schema.Resource {
 				},
 			},
 			"included_scopes": {
-				Description: "Included scopes",
+				Description: "Included scopes; default chosen based on resource group scope if not specified.",
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{

--- a/internal/service/platform/resource_group/resource_group.go
+++ b/internal/service/platform/resource_group/resource_group.go
@@ -44,7 +44,7 @@ func ResourceResourceGroup() *schema.Resource {
 				},
 			},
 			"included_scopes": {
-				Description: "Included scopes; default chosen based on resource group scope if not specified.",
+				Description: "Included scopes; default selected based on resource group scope if not specified.",
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{


### PR DESCRIPTION
## Describe your changes
When setting up a new resource group using Terraform, if a user neglects to specify the included scopes, the backend (BE) takes charge by automatically populating the default scope. 
However, during subsequent changes, Terraform attempts to make the scope null, assuming it was never defined by the user. The snag arises because the backend doesn't permit this operation; the scope is a required field in our database. To enhance clarity, we're updating our documentation to ensure a more transparent understanding of these intricacies.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
