### PR TITLE
fix [PL-42915] : Fix Delegate Token Resource

### DIFF
--- a/docs/resources/platform_delegate_token.md
+++ b/docs/resources/platform_delegate_token.md
@@ -14,23 +14,20 @@ Resource for creating delegate tokens.
 
 ```terraform
 # Create delegate token for account level 
-resource "harness_platform_delegatetoken" "test" {
-  identifier  = "test_token"
+resource "harness_platform_delegatetoken" "test" {  
   name        = "test token"
   account_id  = "account_id"
 }
 
 # Create token for org level apikey
-resource "harness_platform_delegatetoken" "test" {
-  identifier  = "test_token"
+resource "harness_platform_delegatetoken" "test" {  
   name        = "test token"
   account_id  = "account_id"
   org_id      = "org_id"
 }
 
 # Create token for project level apikey
-resource "harness_platform_delegatetoken" "test" {
-  identifier  = "test_token"
+resource "harness_platform_delegatetoken" "test" {  
   name        = "test token"
   account_id  = "account_id"
   org_id      = "org_id"
@@ -44,7 +41,6 @@ resource "harness_platform_delegatetoken" "test" {
 ### Required
 
 - `account_id` (String) Account Identifier for the Entity
-- `identifier` (String) Unique identifier of the resource.
 - `name` (String) Name of the resource.
 
 ### Optional

--- a/internal/service/platform/delegate_token/resource_delegateToken.go
+++ b/internal/service/platform/delegate_token/resource_delegateToken.go
@@ -23,11 +23,6 @@ func ResourceDelegateToken() *schema.Resource {
 		Importer:      helpers.MultiLevelResourceImporter,
 
 		Schema: map[string]*schema.Schema{
-			"identifier": {
-				Description: "Identifier of the delegate token",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
 			"name": {
 				Description: "Name of the delegate token",
 				Type:        schema.TypeString,
@@ -94,7 +89,7 @@ func resourceDelegateTokenRead(ctx context.Context, d *schema.ResourceData, meta
 		return helpers.HandleApiError(err, d, httpResp)
 	}
 
-	if resp.Resource != nil {
+	if resp.Resource != nil && (len(resp.Resource) > 0) {
 		readDelegateToken(d, &resp.Resource[0])
 	}
 
@@ -116,10 +111,7 @@ func resourceDelegateTokenCreateOrUpdate(ctx context.Context, d *schema.Resource
 			ProjectIdentifier: helpers.BuildField(d, "project_id"),
 		})
 	} else {
-		resp, httpResp, err = c.DelegateTokenResourceApi.RevokeDelegateToken(ctx, c.AccountId, delegateToken.Name, &nextgen.DelegateTokenResourceApiRevokeDelegateTokenOpts{
-			OrgIdentifier:     helpers.BuildField(d, "org_id"),
-			ProjectIdentifier: helpers.BuildField(d, "project_id"),
-		})
+		return diag.Errorf("Update operation is not allowed for Delegate Token resource.")
 	}
 
 	if err != nil {
@@ -183,7 +175,6 @@ func buildDelegateToken(d *schema.ResourceData) *nextgen.DelegateTokenDetails {
 
 func readDelegateToken(d *schema.ResourceData, delegateTokenDetails *nextgen.DelegateTokenDetails) {
 	d.SetId(delegateTokenDetails.Name)
-	d.Set("identifier", delegateTokenDetails.Name)
 	d.Set("name", delegateTokenDetails.Name)
 	d.Set("account_id", delegateTokenDetails.AccountId)
 	d.Set("token_status", delegateTokenDetails.Status)

--- a/internal/service/platform/delegate_token/resource_delegateToken_test.go
+++ b/internal/service/platform/delegate_token/resource_delegateToken_test.go
@@ -84,8 +84,7 @@ func TestAccResourceDelegateTokenProjectLevel(t *testing.T) {
 
 func tesAccResourceDelegateToken(name string, accountId string) string {
 	return fmt.Sprintf(`
-		resource "harness_platform_delegatetoken" "test" {
-			identifier = "%[1]s"
+		resource "harness_platform_delegatetoken" "test" {			
 			name = "%[1]s"
 			account_id = "%[2]s"
 		}
@@ -99,8 +98,7 @@ func tesAccResourceDelegateTokenOrgLevel(name string, accountId string, org_id s
 			name = "%[1]s"
 		}
 
-		resource "harness_platform_delegatetoken" "test" {
-			identifier = "%[1]s"
+		resource "harness_platform_delegatetoken" "test" {			
 			name = "%[1]s"
 			account_id = "%[2]s"
 			org_id = harness_platform_organization.test.id
@@ -122,8 +120,7 @@ func tesAccResourceDelegateTokenProjectLevel(name string, accountId string, org_
 			color = "#472848"
 		}
 
-		resource "harness_platform_delegatetoken" "test" {
-			identifier = "%[1]s"
+		resource "harness_platform_delegatetoken" "test" {			
 			name = "%[1]s"
 			account_id = "%[2]s"
 			org_id = harness_platform_organization.test.id


### PR DESCRIPTION
## Describe your changes

- This PR Fixes The delegate token resource , which crashed when terraform apply was done on same resource without any change 
- This PR Removes Identifier from Delegate Resource which is not needed
- This PR prohibits the update operation which unnecessarily  called revoke method leading to confusion

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
