### PR TITLE
fix: [PL-43082]: Fixes the Panic State In Harness Secret File Resource

### DIFF
--- a/internal/service/platform/secret/file.go
+++ b/internal/service/platform/secret/file.go
@@ -148,8 +148,10 @@ func buildTag(no_of_tags int, tags *schema.Set) string {
 	return result
 }
 
-
 func readSecretFile(d *schema.ResourceData, secret *nextgen.Secret) error {
+	if secret == nil {
+		return nil
+	}
 	d.Set("secret_manager_identifier", secret.File.SecretManagerIdentifier)
 	d.SetId(secret.Identifier)
 	d.Set("identifier", secret.Identifier)


### PR DESCRIPTION
## Describe your changes
This PR fixes the panic state of the resource Harness Secret File . The details of which are mentioned over here 
Issue -> https://github.com/harness/terraform-provider-harness/issues/773

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
