### PR TITLE
fix:CDS-82328:Added Documentation link and more details for the Docker Connector

### DIFF
--- a/docs/resources/platform_connector_docker.md
+++ b/docs/resources/platform_connector_docker.md
@@ -142,7 +142,7 @@ resource "harness_platform_connector_docker" "test" {
 
 Required:
 
-- `password_ref` (String) The reference to the Harness secret containing the password to use for the docker registry. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+- `password_ref` (String) The reference to the Harness secret containing the password to use for the docker registry. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}. To reference a secret at the project scope, use directly without any prefix.
 
 Optional:
 

--- a/docs/resources/platform_connector_docker.md
+++ b/docs/resources/platform_connector_docker.md
@@ -10,8 +10,13 @@ description: |-
 
 Resource for creating a Docker connector.
 
-## Example Usage
+### References:
+- For details on how to onboard with Terraform, please see [Harness Terraform Provider Overview](https://developer.harness.io/docs/platform/terraform/harness-terraform-provider-overview/)
+- To understand how to use the Connectors, please see [Documentation](https://developer.harness.io/docs/category/connectors)
+- To understand more about Docker Connectors, please see  [Docker Connectors](https://developer.harness.io/docs/platform/connectors/cloud-providers/ref-cloud-providers/docker-registry-connector-settings-reference/)
 
+## Example to create Docker Connector at different levels (Org, Project, Account)
+### Account Level
 ```terraform
 # credentials anonymous
 resource "harness_platform_connector_docker" "test" {
@@ -31,6 +36,72 @@ resource "harness_platform_connector_docker" "test" {
   name        = "name"
   description = "test"
   tags        = ["foo:bar"]
+
+  type               = "DockerHub"
+  url                = "https://hub.docker.com"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    username     = "admin"
+    password_ref = "account.secret_id"
+  }
+}
+```
+### Org Level
+```terraform
+# credentials anonymous
+resource "harness_platform_connector_docker" "test" {
+  identifier  = "identifer"
+  name        = "name"
+  description = "test"
+  tags        = ["foo:bar"]
+  org_id      = harness_platform_project.test.org_id
+
+  type               = "DockerHub"
+  url                = "https://hub.docker.com"
+  delegate_selectors = ["harness-delegate"]
+}
+
+# credentials username password
+resource "harness_platform_connector_docker" "test" {
+  identifier  = "identifer"
+  name        = "name"
+  description = "test"
+  tags        = ["foo:bar"]
+  org_id      = harness_platform_project.test.org_id
+
+  type               = "DockerHub"
+  url                = "https://hub.docker.com"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    username     = "admin"
+    password_ref = "account.secret_id"
+  }
+}
+```
+### Project Level
+```terraform
+# credentials anonymous
+resource "harness_platform_connector_docker" "test" {
+  identifier  = "identifer"
+  name        = "name"
+  description = "test"
+  tags        = ["foo:bar"]
+  org_id      = harness_platform_project.test.org_id
+  project_id  = harness_platform_project.test.id
+
+  type               = "DockerHub"
+  url                = "https://hub.docker.com"
+  delegate_selectors = ["harness-delegate"]
+}
+
+# credentials username password
+resource "harness_platform_connector_docker" "test" {
+  identifier  = "identifer"
+  name        = "name"
+  description = "test"
+  tags        = ["foo:bar"]
+  org_id      = harness_platform_project.test.org_id
+  project_id  = harness_platform_project.test.id
 
   type               = "DockerHub"
   url                = "https://hub.docker.com"


### PR DESCRIPTION
## Describe your changes
Added different documentation links + added more details in doc for the creating the Docker Connector.
<img width="1083" alt="Screenshot 2023-12-04 at 1 09 25 PM" src="https://github.com/harness/terraform-provider-harness/assets/142882849/e1e44b19-6d93-40a3-97b7-6fb52ad64e05">
<img width="1057" alt="Screenshot 2023-12-04 at 1 09 57 PM" src="https://github.com/harness/terraform-provider-harness/assets/142882849/db9fcfb4-5019-4737-9f6e-7f3a00e1b5e0">
<img width="1164" alt="Screenshot 2023-12-04 at 1 10 09 PM" src="https://github.com/harness/terraform-provider-harness/assets/142882849/67ee3602-7881-4aad-a164-243d848b855b">


## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
