### PR TITLE
Update provider.go

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -114,13 +114,13 @@ func Provider(version string) func() *schema.Provider {
 				"endpoint": {
 					Description: fmt.Sprintf("The URL of the Harness API endpoint. The default is `https://app.harness.io/gateway`. This can also be set using the `%s` environment variable.", helpers.EnvVars.Endpoint.String()),
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc(helpers.EnvVars.Endpoint.String(), utils.BaseUrl),
 				},
 				"account_id": {
 					Description: fmt.Sprintf("The Harness account id. This can also be set using the `%s` environment variable.", helpers.EnvVars.AccountId.String()),
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc(helpers.EnvVars.AccountId.String(), nil),
 				},
 				"api_key": {


### PR DESCRIPTION
clone https://github.com/harness/terraform-provider-harness/pull/748 so its an "internal" change request

credit: @b-diggity

## Describe your changes
When using the Hashicorp Terraform plugin in vscode, the Harness provider is constantly showing in an error state because we pass in `account_id` using an environment variable instead of in the provider definition.  Changing this to optional should remove the plugin errors since the existence of `account_id` in the provider block isn't truly a requirement.  It's a requirement that you pass in the info through an acceptable method.

I'm changing endpoint to be optional too since there appears to be a function that will set a default if one isn't supplied.  It's also in the same boat where the ENV could be used.

![image](https://github.com/harness/terraform-provider-harness/assets/79112218/b5f99b97-9fa4-4a22-b4ef-5190ee044b69)


A couple other examples:
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/provider/provider.go#L34
https://github.com/CheckPointSW/terraform-provider-checkpoint/blob/master/checkpoint/provider.go#L13
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
