### PR TITLE
feat: [FFM-10628]: Give descriptive error on api key conflict

### DIFF
--- a/internal/service/platform/ff_api_key/resource_ff_api_key.go
+++ b/internal/service/platform/ff_api_key/resource_ff_api_key.go
@@ -136,6 +136,10 @@ func resourceFFApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	resp, httpResp, err = c.APIKeysApi.AddAPIKey(ctx, c.AccountId, qp.OrganizationId, qp.EnvironmentId, qp.ProjectId, opts)
 
 	if err != nil {
+		// handle conflict
+		if httpResp != nil && httpResp.StatusCode == 409 {
+			return diag.Errorf("An api key with identifier [%s] orgIdentifier [%s] project [%s]  and environment [%s] already exists", d.Get("identifier").(string), qp.OrganizationId, qp.ProjectId, qp.EnvironmentId)
+		}
 		return helpers.HandleApiError(err, d, httpResp)
 	}
 


### PR DESCRIPTION
## Describe your changes
Previously when getting a conflict when trying to create an api key we'd give a generic terraform error of 
`Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.`

Now we give a more descriptive error of 
`Error: An api key with identifier [pricingservice_key] orgIdentifier [default] project [cmproj]  and environment [prod] already exists`

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
