### PR TITLE
feat: [FFM-10631]: Custom error for flag conflict

### DIFF
--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -426,6 +426,10 @@ func resourceFeatureFlagCreate(ctx context.Context, d *schema.ResourceData, meta
 	httpResp, err = c.FeatureFlagsApi.CreateFeatureFlag(ctx, c.AccountId, qp.OrganizationId, opts)
 
 	if err != nil {
+		// handle conflict
+		if httpResp != nil && httpResp.StatusCode == 409 {
+			return diag.Errorf("A feature flag with identifier [%s] orgIdentifier [%s] project [%s] already exists", d.Get("identifier").(string), qp.OrganizationId, qp.ProjectId)
+		}
 		return helpers.HandleApiError(err, d, httpResp)
 	}
 


### PR DESCRIPTION
## Describe your changes
Previously when getting a conflict when trying to create a flag we'd give a generic terraform error of 
`Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.`

Now we give a more descriptive error of 
`Error: A flagwith identifier [pricingservice_key] orgIdentifier [default] project [cmproj] already exists`

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
