### PR TITLE
feat: [PL-46954]: where project and org is required, new resources are created on updating scope.

### DIFF
--- a/.changelog/859.txt
+++ b/.changelog/859.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/harness_platform_project: where project and org is required, new resources are created on updating scope.
+```

--- a/helpers/schema.go
+++ b/helpers/schema.go
@@ -57,6 +57,11 @@ func GetProjectIdSchema(flag SchemaFlagType) *schema.Schema {
 		Description: "Unique identifier of the project.",
 		Type:        schema.TypeString,
 	}
+
+	if flag == SchemaFlagTypes.Required {
+		s.ForceNew = true
+	}
+
 	SetSchemaFlagType(s, flag)
 	return s
 }
@@ -66,6 +71,11 @@ func GetOrgIdSchema(flag SchemaFlagType) *schema.Schema {
 		Description: "Unique identifier of the organization.",
 		Type:        schema.TypeString,
 	}
+
+	if flag == SchemaFlagTypes.Required {
+		s.ForceNew = true
+	}
+
 	SetSchemaFlagType(s, flag)
 	return s
 }


### PR DESCRIPTION
## Describe your changes

With this change, resources which have projectId/orgId as required parameters will be deleted in the current scope and new resource will be created in the new scope, whenever the scope parameters (projectId/orgId) are changed in the terraform config.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
