### PR TITLE
(FFM-10628) Force delete flags for recreate

### DIFF
--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -485,7 +485,7 @@ func resourceFeatureFlagDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 	qp := buildFFQueryParameters(d)
 
-	httpResp, err := c.FeatureFlagsApi.DeleteFeatureFlag(ctx, d.Id(), c.AccountId, qp.OrganizationId, qp.ProjectId, &nextgen.FeatureFlagsApiDeleteFeatureFlagOpts{CommitMsg: optional.EmptyString()})
+	httpResp, err := c.FeatureFlagsApi.DeleteFeatureFlag(ctx, d.Id(), c.AccountId, qp.OrganizationId, qp.ProjectId, &nextgen.FeatureFlagsApiDeleteFeatureFlagOpts{CommitMsg: optional.EmptyString(), ForceDelete: optional.NewBool(true)})
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)
 	}


### PR DESCRIPTION
## Describe your changes
Some changes require the flag to be deleted then recreated. To support this we need to force delete the flag, otherwise it will only be archived and then will fail to be created and left in a limbo state

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
