### PR TITLE
fix: aws proxy missing subnet

### DIFF
--- a/internal/service/platform/autostopping/load_balancer/aws_proxy.go
+++ b/internal/service/platform/autostopping/load_balancer/aws_proxy.go
@@ -57,6 +57,11 @@ func ResourceAWSProxy() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"subnet_id": {
+				Description: "Subnet to deploy the proxy into",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
 			"allocate_static_ip": {
 				Description: "Boolean value to indicate if proxy vm needs to have static IP",
 				Type:        schema.TypeBool,

--- a/internal/service/platform/autostopping/load_balancer/aws_proxy_data_source.go
+++ b/internal/service/platform/autostopping/load_balancer/aws_proxy_data_source.go
@@ -47,6 +47,11 @@ func DataSourceAWSProxy() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"subnet_id": {
+				Description: "Subnet to deploy the proxy into",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
 			"allocate_static_ip": {
 				Description: "Boolean value to indicate if proxy vm needs to have static IP",
 				Type:        schema.TypeBool,

--- a/internal/service/platform/autostopping/load_balancer/aws_proxy_test.go
+++ b/internal/service/platform/autostopping/load_balancer/aws_proxy_test.go
@@ -55,6 +55,7 @@ func testAWSProxy(name string, hostName string) string {
 			host_name = "%[2]s"
             region = "us-east-1"
 			vpc = "vpc-2657db5c"
+			subnet_id = "subnet-e357d99a"
 			security_groups =["sg-01"]
 			route53_hosted_zone_id = "/hostedzone/hosted_zone_id"
 			machine_type = "t2.medium"
@@ -73,6 +74,7 @@ func testAWSProxyUpdate(name string, hostName string) string {
 			host_name = "%[2]s"
             region = "eastus2"
             vpc = "vpc-2657db5c"
+			subnet_id = "subnet-e357d99a"
 			security_groups =["sg-01","sg-02"]
 			route53_hosted_zone_id = "/hostedzone/hosted_zone_id"
             machine_type = "t2.medium"


### PR DESCRIPTION
## Describe your changes

resource for aws autostopping proxy is missing subnet_id. this is needed to place the proxy in a specific subnet. seems to choose at random otherwise.

test:
```
  # harness_autostopping_aws_proxy.snyder_lab will be created
  + resource "harness_autostopping_aws_proxy" "snyder_lab" {
      + allocate_static_ip                = true
      + api_key                           = (sensitive value)
      + cloud_connector_id                = "rileyharnessccm"
      + delete_cloud_resources_on_destroy = true
      + host_name                         = "192.168.0.1.nip.io"
      + id                                = (known after apply)
      + identifier                        = (known after apply)
      + keypair                           = "riley"
      + machine_type                      = "t3.micro"
      + name                              = "snyder-lab"
      + region                            = "us-west-2"
      + security_groups                   = [
          + "sg-040bd76d805fb4e2e",
        ]
      + subnet_id                         = "subnet-0d91195f6cc504f8e"
      + vpc                               = "vpc-0e2b5e811d1ce6767"
    }
```

![image](https://github.com/harness/terraform-provider-harness/assets/7338312/4c63ccd0-37c1-401d-b025-2543631fc2a7)

![image](https://github.com/harness/terraform-provider-harness/assets/7338312/5d3a87d7-5008-4aa0-8e03-29d39cfa5ea4)


## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
