### PR TITLE
fix: [CDS-93065]: add support for CA certificate on k8s connector

### DIFF
--- a/.changelog/928.txt
+++ b/.changelog/928.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+harness_platform_connector_kubernetes: Added support for ca_cert_ref in kubernetes connector cluster.
+```

--- a/docs/data-sources/platform_connector_kubernetes.md
+++ b/docs/data-sources/platform_connector_kubernetes.md
@@ -86,6 +86,7 @@ Read-Only:
 
 - `master_url` (String)
 - `service_account_token_ref` (String)
+- `ca_cert_ref` (String)
 
 
 <a id="nestedatt--username_password"></a>

--- a/docs/resources/platform_connector_kubernetes.md
+++ b/docs/resources/platform_connector_kubernetes.md
@@ -169,6 +169,10 @@ Required:
 - `master_url` (String) The URL of the Kubernetes cluster.
 - `service_account_token_ref` (String) Reference to the secret containing the service account token for the connector. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
 
+Optional:
+
+- `ca_cert_ref` (String) Reference to the secret containing the CA certificate for the connector. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+
 
 <a id="nestedblock--username_password"></a>
 ### Nested Schema for `username_password`

--- a/internal/service/platform/connector/k8s_cluster.go
+++ b/internal/service/platform/connector/k8s_cluster.go
@@ -143,6 +143,11 @@ func ResourceConnectorK8s() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 						},
+						"ca_cert_ref": {
+							Description: "Reference to the secret containing the CA certificate for the connector." + secret_ref_text,
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 					},
 				},
 			},

--- a/internal/service/platform/connector/k8s_cluster.go
+++ b/internal/service/platform/connector/k8s_cluster.go
@@ -423,6 +423,9 @@ func buildConnectorK8s(d *schema.ResourceData) *nextgen.ConnectorInfo {
 			if attr := config["service_account_token_ref"].(string); attr != "" {
 				saConfig.ServiceAccountTokenRef = attr
 			}
+			if attr := config["ca_cert_ref"].(string); attr != "" {
+				saConfig.CaCertRef = attr
+			}
 		}
 
 		if attr, ok := d.GetOk("service_account"); ok {
@@ -437,6 +440,9 @@ func buildConnectorK8s(d *schema.ResourceData) *nextgen.ConnectorInfo {
 
 			if attr := config["service_account_token_ref"].(string); attr != "" {
 				saConfig.ServiceAccountTokenRef = attr
+			}
+			if attr := config["ca_cert_ref"].(string); attr != "" {
+				saConfig.CaCertRef = attr
 			}
 		}
 
@@ -522,6 +528,7 @@ func readConnectorK8s(d *schema.ResourceData, connector *nextgen.ConnectorInfo) 
 				{
 					"master_url":                connector.K8sCluster.Credential.ManualConfig.MasterUrl,
 					"service_account_token_ref": auth.ServiceAccount.ServiceAccountTokenRef,
+					"ca_cert_ref":               auth.ServiceAccount.CaCertRef,
 				},
 			})
 			d.Set("delegate_selectors", connector.K8sCluster.DelegateSelectors)

--- a/internal/service/platform/connector/k8s_cluster.go
+++ b/internal/service/platform/connector/k8s_cluster.go
@@ -428,24 +428,6 @@ func buildConnectorK8s(d *schema.ResourceData) *nextgen.ConnectorInfo {
 			}
 		}
 
-		if attr, ok := d.GetOk("service_account"); ok {
-			config := attr.([]interface{})[0].(map[string]interface{})
-			saConfig := &nextgen.KubernetesServiceAccount{}
-			connector.K8sCluster.Credential.ManualConfig.Auth.Type_ = nextgen.KubernetesAuthTypes.ServiceAccount
-			connector.K8sCluster.Credential.ManualConfig.Auth.ServiceAccount = saConfig
-
-			if attr := config["master_url"].(string); attr != "" {
-				connector.K8sCluster.Credential.ManualConfig.MasterUrl = attr
-			}
-
-			if attr := config["service_account_token_ref"].(string); attr != "" {
-				saConfig.ServiceAccountTokenRef = attr
-			}
-			if attr := config["ca_cert_ref"].(string); attr != "" {
-				saConfig.CaCertRef = attr
-			}
-		}
-
 		if attr, ok := d.GetOk("openid_connect"); ok {
 			config := attr.([]interface{})[0].(map[string]interface{})
 			oidcConfig := &nextgen.KubernetesOpenIdConnect{}

--- a/internal/service/platform/connector/k8s_cluster_test.go
+++ b/internal/service/platform/connector/k8s_cluster_test.go
@@ -397,6 +397,7 @@ func testAccResourceConnectorK8s_ServiceAccount(id string, name string) string {
 			service_account {
 				master_url = "https://kubernetes.example.com"
 				service_account_token_ref = "account.${harness_platform_secret_text.test.id}"
+				ca_cert_ref = "account.${harness_platform_secret_text.test.id}"
 			}
 			delegate_selectors = ["harness-delegate"]
 


### PR DESCRIPTION
## Describe your changes
Have added support to pass ca certificate for service account based authentication for k8s connector.
<img width="1143" alt="image" src="https://github.com/harness/terraform-provider-harness/assets/105721928/029c86d6-2fdc-41b6-95a7-27e318b73485">

Have also removed a duplicate condition on service account based auth type if condition parsing!
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
