### PR TITLE
(FFM-11034) Make environment attributes optional

### DIFF
--- a/internal/service/platform/feature_flag/resource_feature_flag.go
+++ b/internal/service/platform/feature_flag/resource_feature_flag.go
@@ -133,12 +133,12 @@ func ResourceFeatureFlag() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"variation": {
-										Description: "The identifier of the variation. Valid values are `enabled`, `disabled`",
+										Description: "The identifier of the variation",
 										Type:        schema.TypeString,
 										Optional:    true,
 									},
 									"targets": {
-										Description: "The targets of the rule",
+										Description: "The targets that should be served this variation",
 										Type:        schema.TypeList,
 										Optional:    true,
 										MinItems:    0,
@@ -234,10 +234,10 @@ type FFPutOpts struct {
 
 type Environment struct {
 	Identifier          string        `json:"identifier"`
-	DefaultOnVariation  string        `json:"defaultOnVariation"`
-	DefaultOffVariation string        `json:"defaultOffVariation"`
-	State               string        `json:"state"`
-	TargetRules         []TargetRules `json:"rules"`
+	DefaultOnVariation  string        `json:"defaultOnVariation,omitempty"`
+	DefaultOffVariation string        `json:"defaultOffVariation,omitempty"`
+	State               string        `json:"state,omitempty"`
+	TargetRules         []TargetRules `json:"rules,omitempty"`
 }
 
 type TFEnvironment struct {


### PR DESCRIPTION
## Describe your changes
**Issue**
When setting up a new environment in config it should be optional to pass whichever fields you'd like to manage while leaving the rest empty from `state`, `defaultOnVariation`, `defaultOffVariation` and `rules`.

Previously when configuring the environment for the very first time these would be passed as empty strings and get an error from the backend of 
```
Error applying flag PUT updates: 2 errors occurred:
  | \t* invalid feature state
  | \t* invalid serve object
```

**Steps to reproduce**
Add an environment section to a flag without specifying all the fields e.g. this is missing the `state` field
```
environment {
    identifier = "group"
    default_on_variation  = "true"
    default_off_variation = "false"
  }
```

Logs will show that the PUT operation is sending state="" which leads to a 400 error
```
Error applying flag PUT updates: 1 error occurred:
  | \t* invalid feature state
```

**New behaviour**
With the updated version state won't be sent in the request and no error will be returned from the backend. 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
