### PR TITLE
(FFM-11100) Update ff tags docs

### DIFF
--- a/docs/resources/platform_feature_flag.md
+++ b/docs/resources/platform_feature_flag.md
@@ -45,7 +45,6 @@ resource "harness_platform_feature_flag" "mybooleanflag" {
   }
 
   tags {
-    name       = "mytag"
     identifier = "mytag"
   }
 }

--- a/examples/resources/harness_platform_feature_flag/resource.tf
+++ b/examples/resources/harness_platform_feature_flag/resource.tf
@@ -30,7 +30,6 @@ resource "harness_platform_feature_flag" "mybooleanflag" {
   }
 
   tags {
-    name       = "mytag"
     identifier = "mytag"
   }
 }


### PR DESCRIPTION
## Describe your changes
Name isn't currently supported for ff tags in terraform (it's always assigned the same value as identifier), so remove it from the docs examples or they'll produce errors

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
