### PR TITLE
feat: [PL-48648]: Update TF support for AWS secret manager

### DIFF
--- a/internal/service/platform/connector/aws_data_source.go
+++ b/internal/service/platform/connector/aws_data_source.go
@@ -32,6 +32,11 @@ func DatasourceConnectorAws() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
+						"access_key_plain_text": {
+							Description: "The plain text AWS access key.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"delegate_selectors": {
 							Description: "Connect only use delegates with these tags.",
 							Type:        schema.TypeSet,

--- a/internal/service/platform/connector/aws_secret_manager.go
+++ b/internal/service/platform/connector/aws_secret_manager.go
@@ -38,9 +38,9 @@ func ResourceConnectorAwsSM() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"default": {
-				Description:   "Use as Default Secrets Manager.",
-				Type:          schema.TypeBool,
-				Optional:      true,
+				Description: "Use as Default Secrets Manager.",
+				Type:        schema.TypeBool,
+				Optional:    true,
 			},
 			"credentials": {
 				Description: "Credentials to connect to AWS.",
@@ -67,6 +67,11 @@ func ResourceConnectorAwsSM() *schema.Resource {
 										Description: "The reference to the Harness secret containing the AWS secret key." + secret_ref_text,
 										Type:        schema.TypeString,
 										Required:    true,
+									},
+									"access_key_plain_text": {
+										Description: "The plain text AWS access key.",
+										Type:        schema.TypeString,
+										Optional:    true,
 									},
 								},
 							},
@@ -200,6 +205,9 @@ func buildConnectorAwsSM(d *schema.ResourceData) *nextgen.ConnectorInfo {
 			if attr, ok := config["secret_key_ref"]; ok {
 				connector.AwsSecretManager.Credential.ManualConfig.SecretKey = attr.(string)
 			}
+			if attr, ok := config["access_key_plain_text"]; ok {
+				connector.AwsSecretManager.Credential.ManualConfig.AccessKeyPlainText = attr.(string)
+			}
 		}
 
 		if attr := config["assume_role"].([]interface{}); len(attr) > 0 {
@@ -242,8 +250,9 @@ func readConnectorAwsSM(d *schema.ResourceData, connector *nextgen.ConnectorInfo
 			map[string]interface{}{
 				"manual": []interface{}{
 					map[string]interface{}{
-						"access_key_ref": connector.AwsSecretManager.Credential.ManualConfig.AccessKey,
-						"secret_key_ref": connector.AwsSecretManager.Credential.ManualConfig.SecretKey,
+						"access_key_ref":        connector.AwsSecretManager.Credential.ManualConfig.AccessKey,
+						"secret_key_ref":        connector.AwsSecretManager.Credential.ManualConfig.SecretKey,
+						"access_key_plain_text": connector.AwsSecretManager.Credential.ManualConfig.AccessKeyPlainText,
 					},
 				},
 			},


### PR DESCRIPTION
## Describe your changes


Update TF support for AWS secret manager where now for access key can be added as either secret reference or plain text.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
