### PR TITLE
fix: [CDS-99254]: Fix import flow for app project mapping

### DIFF
--- a/.changelog/1020.txt
+++ b/.changelog/1020.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+resource/harness_platform_gitops_app_project_mapping  fix import flow
+```

--- a/docs/data-sources/platform_gitops_app_project_mapping.md
+++ b/docs/data-sources/platform_gitops_app_project_mapping.md
@@ -14,11 +14,11 @@ Resource for managing the Harness GitOps Application Project Mappings.
 
 ```terraform
 data "harness_platform_gitops_app_project_mapping" "example" {
-  identifier = "identifier"
   account_id = "account_id"
   org_id     = "organization_id"
   project_id = "project_id"
   agent_id   = "agent_id"
+  argo_proj_name = "argo_proj_name"
 }
 ```
 

--- a/examples/data-sources/harness_platform_gitops_app_project_mapping/data-source.tf
+++ b/examples/data-sources/harness_platform_gitops_app_project_mapping/data-source.tf
@@ -1,7 +1,7 @@
 data "harness_platform_gitops_app_project_mapping" "example" {
-  identifier = "identifier"
   account_id = "account_id"
   org_id     = "organization_id"
   project_id = "project_id"
   agent_id   = "agent_id"
+  argo_proj_name = "argo_proj_name"
 }

--- a/examples/resources/harness_platform_gitops_app_project_mapping/import.sh
+++ b/examples/resources/harness_platform_gitops_app_project_mapping/import.sh
@@ -1,2 +1,2 @@
 # Import a GitOps agent app project mapping
-terraform import harness_platform_gitops_app_project_mapping.example <organization_id>/<project_id>/<agent_id>/<appproject_id>
+terraform import harness_platform_gitops_app_project_mapping.example <organization_id>/<project_id>/<agent_id>/<appproject_name>

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.46.4
 	github.com/docker/docker v24.0.5+incompatible
-	github.com/harness/harness-go-sdk v0.4.0
+	github.com/harness/harness-go-sdk v0.4.1
 	github.com/harness/harness-openapi-go-client v0.0.21
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/harness/harness-go-sdk v0.4.0 h1:+3VTKMNkXEeg35771ybcFqZDK/vgLQsqd7XaFWIRzrE=
-github.com/harness/harness-go-sdk v0.4.0/go.mod h1:a/1HYTgVEuNEoh3Z3IsOHZdlUNxl94KcX57ZSNVGll0=
+github.com/harness/harness-go-sdk v0.4.1 h1:T42mXbfJDkZrroY79pzN8MolDcDhvHje0EpgeRjv+pY=
+github.com/harness/harness-go-sdk v0.4.1/go.mod h1:a/1HYTgVEuNEoh3Z3IsOHZdlUNxl94KcX57ZSNVGll0=
 github.com/harness/harness-openapi-go-client v0.0.21 h1:VtJnpQKZvCAlaCmUPbNR69OT3c5WRdhNN5TOgUwtwZ4=
 github.com/harness/harness-openapi-go-client v0.0.21/go.mod h1:u0vqYb994BJGotmEwJevF4L3BNAdU9i8ui2d22gmLPA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/helpers/schema.go
+++ b/helpers/schema.go
@@ -410,6 +410,28 @@ var GitopsAgentResourceImporter = &schema.ResourceImporter{
 }
 
 // GitopsAgentResourceImporter defines the importer configuration for all project level gitops agent resources.
+// The id used for the import should be in the format <org_id>/<project_id>/<identifier>/<agentId>
+var GitopsAppProjectMappingImporter = &schema.ResourceImporter{
+	State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+		parts := strings.Split(d.Id(), "/")
+
+		// Approject mapping always has 4 parts
+		if len(parts) == 4 { //Project level
+			d.Set("org_id", parts[0])
+			d.Set("project_id", parts[1])
+			d.Set("agent_id", parts[2])
+			d.Set("argo_project_name", parts[3])
+			// During import we are using argo_project_name as identifier not the actual identifier
+			// So we are not fetching mapping by mongo id but by argo_project_name, agent_id, account_id, org_id and project_id.
+			d.SetId(parts[3])
+			return []*schema.ResourceData{d}, nil
+		}
+
+		return nil, fmt.Errorf("invalid identifier: %s", d.Id())
+	},
+}
+
+// GitopsAgentResourceImporter defines the importer configuration for all project level gitops agent resources.
 // The id used for the import should be in the format <agent_id>/<query_name>
 var GitopsAgentProjectImporter = &schema.ResourceImporter{
 	State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/helpers/schema.go
+++ b/helpers/schema.go
@@ -409,8 +409,9 @@ var GitopsAgentResourceImporter = &schema.ResourceImporter{
 	},
 }
 
-// GitopsAgentResourceImporter defines the importer configuration for all project level gitops agent resources.
-// The id used for the import should be in the format <org_id>/<project_id>/<identifier>/<agentId>
+// GitopsAppProjectMappingImporter defines the importer configuration for app project mapping.
+// The id used for the import should be in the format <org_id>/<project_id>/<identifier>/<argo_project_name>\
+// It is used always at project level.
 var GitopsAppProjectMappingImporter = &schema.ResourceImporter{
 	State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 		parts := strings.Split(d.Id(), "/")
@@ -421,8 +422,8 @@ var GitopsAppProjectMappingImporter = &schema.ResourceImporter{
 			d.Set("project_id", parts[1])
 			d.Set("agent_id", parts[2])
 			d.Set("argo_project_name", parts[3])
-			// During import we are using argo_project_name as identifier not the actual identifier
-			// So we are not fetching mapping by mongo id but by argo_project_name, agent_id, account_id, org_id and project_id.
+			// During import we are using argo_project_name as identifier not the actual identifier which is mongo id
+			// that way we are not fetching mapping by mongo id but by argo_project_name, agent_id, account_id, org_id and project_id.
 			d.SetId(parts[3])
 			return []*schema.ResourceData{d}, nil
 		}

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -248,6 +248,19 @@ func GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName string) resou
 	return func(s *terraform.State) (string, error) {
 		primary := s.RootModule().Resources[resourceName].Primary
 		id := primary.ID
+
+		orgId := primary.Attributes["org_id"]
+		projId := primary.Attributes["project_id"]
+		agentId := primary.Attributes["agent_id"]
+		return fmt.Sprintf("%s/%s/%s/%s", orgId, projId, agentId, id), nil
+	}
+}
+
+func GitopsAppProjectMappingResourceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		primary := s.RootModule().Resources[resourceName].Primary
+		id := primary.ID
+
 		orgId := primary.Attributes["org_id"]
 		projId := primary.Attributes["project_id"]
 		agentId := primary.Attributes["agent_id"]

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -259,12 +259,12 @@ func GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName string) resou
 func GitopsAppProjectMappingResourceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		primary := s.RootModule().Resources[resourceName].Primary
-		id := primary.ID
 
 		orgId := primary.Attributes["org_id"]
 		projId := primary.Attributes["project_id"]
 		agentId := primary.Attributes["agent_id"]
-		return fmt.Sprintf("%s/%s/%s/%s", orgId, projId, agentId, id), nil
+		argoProjName := primary.Attributes["argo_project_name"]
+		return fmt.Sprintf("%s/%s/%s/%s", orgId, projId, agentId, argoProjName), nil
 	}
 }
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -256,6 +256,8 @@ func GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName string) resou
 	}
 }
 
+// Import of GitopsAppProjectMapping resource is always on project level
+// terraform import  harness_platform_gitops_app_project_mapping.example org_id/projec_id/scope_prefixed_agent_id/argo_proj_name
 func GitopsAppProjectMappingResourceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		primary := s.RootModule().Resources[resourceName].Primary

--- a/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping.go
@@ -16,7 +16,7 @@ func DatasourceGitopsAppProjectMapping() *schema.Resource {
 		Description: "Resource for managing the Harness GitOps Application Project Mappings.",
 
 		ReadContext: datasourceGitopsAppProjectMappingRead,
-		Importer:    helpers.ProjectResourceImporter,
+		Importer:    helpers.GitopsAppProjectMappingImporter,
 
 		Schema: map[string]*schema.Schema{
 			"account_id": {
@@ -59,10 +59,15 @@ func datasourceGitopsAppProjectMappingRead(ctx context.Context, d *schema.Resour
 	ctx = context.WithValue(ctx, nextgen.ContextAccessToken, hh.EnvVars.BearerToken.Get())
 	agentIdentifier := d.Get("agent_id").(string)
 	identifier := d.Get("identifier").(string)
+	argo_proj_name := d.Get("argo_project_name").(string)
+	if identifier == argo_proj_name {
+		identifier = ""
+	}
 	resp, httpResp, err := c.ProjectMappingsApi.AppProjectMappingServiceGetAppProjectMappingV2(ctx, agentIdentifier, identifier, &nextgen.ProjectMappingsApiAppProjectMappingServiceGetAppProjectMappingV2Opts{
 		AccountIdentifier: optional.NewString(c.AccountId),
 		OrgIdentifier:     optional.NewString(d.Get("org_id").(string)),
 		ProjectIdentifier: optional.NewString(d.Get("project_id").(string)),
+		ArgoProjectName:   optional.NewString(argo_proj_name),
 	})
 
 	if err != nil {

--- a/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping_test.go
+++ b/internal/service/platform/gitops/app_project/datasource_gitops_app_project_mapping_test.go
@@ -72,12 +72,12 @@ func testAccDatasourceGitopsAppProjectMapping(agentId string, accountId string, 
 
 		data "harness_platform_gitops_app_project_mapping" test1 {
 			depends_on = [harness_platform_gitops_app_project_mapping.test]
-			identifier = harness_platform_gitops_app_project_mapping.test.identifier
 			
 			org_id = harness_platform_organization.test.id
 			account_id = "%[2]s"
 			project_id = harness_platform_project.test.id
 			agent_id = "%[1]s"
+            argo_project_name = "%[3]s"
 		}
 		`, agentId, accountId, argoProject)
 }

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
@@ -2,8 +2,6 @@ package app_project
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/antihax/optional"
 	hh "github.com/harness/harness-go-sdk/harness/helpers"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
@@ -85,10 +83,10 @@ func resourceGitopsAppProjectMappingRead(ctx context.Context, d *schema.Resource
 	agentIdentifier := d.Get("agent_id").(string)
 	identifier := d.Get("identifier").(string)
 	argo_proj_name := d.Get("argo_project_name").(string)
-	// During import we are using argo_project_name as identifier not the actual identifier
+	// During import we are using argo_project_name as identifier not the actual identifier which is mongo id
 	// So we are not fetching mapping by mongo id but by argo_project_name, agent_id, account_id, org_id and project_id.
+	// argo_project_name, agent_id, account_id, org_id and project_id uniquely identify mapping.
 	if identifier == argo_proj_name {
-		fmt.Println("identifier and argo_project_name are same")
 		identifier = ""
 	}
 	resp, httpResp, err := c.ProjectMappingsApi.AppProjectMappingServiceGetAppProjectMappingV2(ctx, agentIdentifier, identifier, &nextgen.ProjectMappingsApiAppProjectMappingServiceGetAppProjectMappingV2Opts{

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
@@ -2,6 +2,7 @@ package app_project
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/antihax/optional"
 	hh "github.com/harness/harness-go-sdk/harness/helpers"
@@ -20,7 +21,7 @@ func ResourceGitopsAppProjectMapping() *schema.Resource {
 		ReadContext:   resourceGitopsAppProjectMappingRead,
 		UpdateContext: resourceGitopsAppProjectMappingUpdate,
 		DeleteContext: resourceGitopsAppProjectMappingDelete,
-		Importer:      helpers.GitopsAgentResourceImporter,
+		Importer:      helpers.GitopsAppProjectMappingImporter,
 
 		Schema: map[string]*schema.Schema{
 			"account_id": {
@@ -83,10 +84,18 @@ func resourceGitopsAppProjectMappingRead(ctx context.Context, d *schema.Resource
 	ctx = context.WithValue(ctx, nextgen.ContextAccessToken, hh.EnvVars.BearerToken.Get())
 	agentIdentifier := d.Get("agent_id").(string)
 	identifier := d.Get("identifier").(string)
+	argo_proj_name := d.Get("argo_project_name").(string)
+	// During import we are using argo_project_name as identifier not the actual identifier
+	// So we are not fetching mapping by mongo id but by argo_project_name, agent_id, account_id, org_id and project_id.
+	if identifier == argo_proj_name {
+		fmt.Println("identifier and argo_project_name are same")
+		identifier = ""
+	}
 	resp, httpResp, err := c.ProjectMappingsApi.AppProjectMappingServiceGetAppProjectMappingV2(ctx, agentIdentifier, identifier, &nextgen.ProjectMappingsApiAppProjectMappingServiceGetAppProjectMappingV2Opts{
 		AccountIdentifier: optional.NewString(c.AccountId),
 		OrgIdentifier:     optional.NewString(d.Get("org_id").(string)),
 		ProjectIdentifier: optional.NewString(d.Get("project_id").(string)),
+		ArgoProjectName:   optional.NewString(argo_proj_name),
 	})
 
 	if err != nil {

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
@@ -19,7 +19,6 @@ import (
 func TestAccResourceGitopsAppProjectMapping(t *testing.T) {
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
 	id = strings.ReplaceAll(id, "_", "")
-	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
 	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
 	resourceName := "harness_platform_gitops_app_project_mapping.test"
 	argoProject := "test123"
@@ -30,13 +29,13 @@ func TestAccResourceGitopsAppProjectMapping(t *testing.T) {
 		// CheckDestroy:      testAccResourceGitopsAppProjectMappingDestroy(resourceName, agentId), //commenting this since app project mapping cannot exist without an agent.
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceGitopsAppProjectMapping(agentId, accountId, argoProject, "mirko"),
+				Config: testAccResourceGitopsAppProjectMapping(id, accountId, argoProject, id),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "argo_project_name", argoProject),
 				),
 			},
 			{
-				Config: testAccResourceGitopsAppProjectMapping(agentId, accountId, argoProjectUpdated, "ashintest"),
+				Config: testAccResourceGitopsAppProjectMapping(id, accountId, argoProjectUpdated, id),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "argo_project_name", argoProjectUpdated),
 				),
@@ -45,7 +44,7 @@ func TestAccResourceGitopsAppProjectMapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: acctest.GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName),
+				ImportStateIdFunc: acctest.GitopsAppProjectMappingResourceImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -78,31 +77,31 @@ func testAccResourceGitopsAppProjectMappingDestroy(resourceName string, agentId 
 	}
 }
 
-func testAccResourceGitopsAppProjectMapping(agentId string, accountId string, argoProject string, projectId string) string {
+func testAccResourceGitopsAppProjectMapping(id string, accountId string, argoProject string, projectId string) string {
 	return fmt.Sprintf(`
-		//resource "harness_platform_organization" "test" {
-		//	identifier = "%[1]s"
-		//	name = "%[1]s"
-		//}
-		//
-		//resource "harness_platform_project" "test" {
-		//	identifier = "%[1]s"
-		//	name = "%[1]s"
-		//	org_id = harness_platform_organization.test.id
-		//}
-		//resource "harness_platform_gitops_agent" "test" {
-		//	identifier = "%[1]s"
-		//	account_id = "%[2]s"
-		//	org_id = harness_platform_organization.test.id
-		//	project_id = harness_platform_project.test.id
-		//	name = "%[1]s"
-		//	type = "MANAGED_ARGO_PROVIDER"
-		//	operator = "ARGO"
-		//	metadata {
-		//		namespace = "%[1]s"
-        //		high_availability = false
-    	//	}
-		//}
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[1]s"
+		}
+		
+		resource "harness_platform_project" "test" {
+			identifier = "%[4]s"
+			name = "%[4]s"
+			org_id = harness_platform_organization.test.id
+		}
+		resource "harness_platform_gitops_agent" "test" {
+			identifier = "%[1]s"
+			account_id = "%[2]s"
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			name = "%[1]s"
+			type = "MANAGED_ARGO_PROVIDER"
+			operator = "ARGO"
+			metadata {
+				namespace = "%[1]s"
+        		high_availability = false
+    		}
+		}
 		resource "harness_platform_gitops_app_project_mapping" "test" {
 			//depends_on = [harness_platform_gitops_agent.test]
 			account_id = "%[2]s"
@@ -111,5 +110,5 @@ func testAccResourceGitopsAppProjectMapping(agentId string, accountId string, ar
 			agent_id = "%[1]s"
 			argo_project_name = "%[3]s"
 		}
-		`, agentId, accountId, argoProject, projectId)
+		`, id, accountId, argoProject, projectId)
 }

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
@@ -19,6 +19,7 @@ import (
 func TestAccResourceGitopsAppProjectMapping(t *testing.T) {
 	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
 	id = strings.ReplaceAll(id, "_", "")
+	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
 	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
 	resourceName := "harness_platform_gitops_app_project_mapping.test"
 	argoProject := "test123"
@@ -29,13 +30,13 @@ func TestAccResourceGitopsAppProjectMapping(t *testing.T) {
 		// CheckDestroy:      testAccResourceGitopsAppProjectMappingDestroy(resourceName, agentId), //commenting this since app project mapping cannot exist without an agent.
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceGitopsAppProjectMapping(id, accountId, argoProject),
+				Config: testAccResourceGitopsAppProjectMapping(agentId, accountId, argoProject, "mirko"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "argo_project_name", argoProject),
 				),
 			},
 			{
-				Config: testAccResourceGitopsAppProjectMapping(id, accountId, argoProjectUpdated),
+				Config: testAccResourceGitopsAppProjectMapping(agentId, accountId, argoProjectUpdated, "ashintest"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "argo_project_name", argoProjectUpdated),
 				),
@@ -77,38 +78,38 @@ func testAccResourceGitopsAppProjectMappingDestroy(resourceName string, agentId 
 	}
 }
 
-func testAccResourceGitopsAppProjectMapping(agentId string, accountId string, argoProject string) string {
+func testAccResourceGitopsAppProjectMapping(agentId string, accountId string, argoProject string, projectId string) string {
 	return fmt.Sprintf(`
-		resource "harness_platform_organization" "test" {
-			identifier = "%[1]s"
-			name = "%[1]s"
-		}
-
-		resource "harness_platform_project" "test" {
-			identifier = "%[1]s"
-			name = "%[1]s"
-			org_id = harness_platform_organization.test.id
-		}
-		resource "harness_platform_gitops_agent" "test" {
-			identifier = "%[1]s"
-			account_id = "%[2]s"
-			org_id = harness_platform_organization.test.id
-			project_id = harness_platform_project.test.id
-			name = "%[1]s"
-			type = "MANAGED_ARGO_PROVIDER"
-			operator = "ARGO"
-			metadata {
-				namespace = "%[1]s"
-        		high_availability = false
-    		}
-		}
+		//resource "harness_platform_organization" "test" {
+		//	identifier = "%[1]s"
+		//	name = "%[1]s"
+		//}
+		//
+		//resource "harness_platform_project" "test" {
+		//	identifier = "%[1]s"
+		//	name = "%[1]s"
+		//	org_id = harness_platform_organization.test.id
+		//}
+		//resource "harness_platform_gitops_agent" "test" {
+		//	identifier = "%[1]s"
+		//	account_id = "%[2]s"
+		//	org_id = harness_platform_organization.test.id
+		//	project_id = harness_platform_project.test.id
+		//	name = "%[1]s"
+		//	type = "MANAGED_ARGO_PROVIDER"
+		//	operator = "ARGO"
+		//	metadata {
+		//		namespace = "%[1]s"
+        //		high_availability = false
+    	//	}
+		//}
 		resource "harness_platform_gitops_app_project_mapping" "test" {
-			depends_on = [harness_platform_gitops_agent.test]
+			//depends_on = [harness_platform_gitops_agent.test]
 			account_id = "%[2]s"
-			org_id = harness_platform_organization.test.id
-			project_id = harness_platform_project.test.id
+			org_id = "default"
+			project_id = "%[4]s"
 			agent_id = "%[1]s"
 			argo_project_name = "%[3]s"
 		}
-		`, agentId, accountId, argoProject)
+		`, agentId, accountId, argoProject, projectId)
 }

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping_test.go
@@ -103,9 +103,9 @@ func testAccResourceGitopsAppProjectMapping(id string, accountId string, argoPro
     		}
 		}
 		resource "harness_platform_gitops_app_project_mapping" "test" {
-			//depends_on = [harness_platform_gitops_agent.test]
+			depends_on = [harness_platform_gitops_agent.test]
 			account_id = "%[2]s"
-			org_id = "default"
+			org_id = "%[1]s"
 			project_id = "%[4]s"
 			agent_id = "%[1]s"
 			argo_project_name = "%[3]s"


### PR DESCRIPTION
## Describe your changes

changing the import flow

import will be now 
```
terraform import  harness_platform_gitops_app_project_mapping.example org_id/proj_id/<scope_prefixed_agent_id>/argo_proj_name
```

instead of previous 
```
terraform import  harness_platform_gitops_app_project_mapping.example org_id/proj_id/<scope_prefixed_agent_id>/mongo_id
```

related prs

https://github.com/wings-software/gitops/pull/2919
https://github.com/harness/harness-go-sdk/pull/554



## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
