### PR TITLE
fix: [CDS-100484]: Improve error handling for gitops and recreate gitops resources if they are deleted and existing in terraform state.

### DIFF
--- a/.changelog/1022.txt
+++ b/.changelog/1022.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+Improve error handling for gitops, recreate resource if exists in terraform state but deleted outside of terraform flow.
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.46.4
 	github.com/docker/docker v24.0.5+incompatible
-	github.com/harness/harness-go-sdk v0.4.1
+	github.com/harness/harness-go-sdk v0.4.3
 	github.com/harness/harness-openapi-go-client v0.0.21
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.1
+	google.golang.org/grpc v1.61.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -80,7 +81,6 @@ require (
 	golang.org/x/tools v0.19.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect
-	google.golang.org/grpc v1.61.0 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/harness/harness-go-sdk v0.4.1 h1:T42mXbfJDkZrroY79pzN8MolDcDhvHje0EpgeRjv+pY=
-github.com/harness/harness-go-sdk v0.4.1/go.mod h1:a/1HYTgVEuNEoh3Z3IsOHZdlUNxl94KcX57ZSNVGll0=
+github.com/harness/harness-go-sdk v0.4.3 h1:lAyQT7paCayYIOPrZPmCHOtG2uWCgUHugcaN9MJtYnE=
+github.com/harness/harness-go-sdk v0.4.3/go.mod h1:a/1HYTgVEuNEoh3Z3IsOHZdlUNxl94KcX57ZSNVGll0=
 github.com/harness/harness-openapi-go-client v0.0.21 h1:VtJnpQKZvCAlaCmUPbNR69OT3c5WRdhNN5TOgUwtwZ4=
 github.com/harness/harness-openapi-go-client v0.0.21/go.mod h1:u0vqYb994BJGotmEwJevF4L3BNAdU9i8ui2d22gmLPA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"google.golang.org/grpc/codes"
 	"net/http"
 
 	"github.com/harness/harness-go-sdk/harness/dbops"
@@ -12,51 +13,7 @@ import (
 )
 
 func HandleApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
-	erro, ok := err.(nextgen.GenericSwaggerError)
-	if ok {
-		if httpResp != nil && httpResp.StatusCode == 401 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if token has expired or is wrong.\n" +
-				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
-		}
-		if httpResp != nil && httpResp.StatusCode == 403 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if the token has required permission for this operation.\n" +
-				"2) Please check if the token has expired or is wrong.")
-		}
-		if httpResp != nil && httpResp.StatusCode == 404 {
-			return diag.Errorf("resource with ID %s not found: %v", d.Id(), erro.Error())
-		}
-		return diag.Errorf(erro.Error())
-	}
-
-	err_openapi_client, ok := err.(openapi_client_nextgen.GenericSwaggerError)
-	if ok {
-		if httpResp != nil && httpResp.StatusCode == 401 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if token has expired or is wrong.\n" +
-				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
-		}
-
-		if httpResp != nil && httpResp.StatusCode == 403 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if the token has required permission for this operation.\n" +
-				"2) Please check if the token has expired or is wrong.")
-		}
-
-		if httpResp != nil && httpResp.StatusCode == 404 {
-			return diag.Errorf("resource with ID %s not found: %v", d.Id(), erro.Error())
-		}
-
-		var jsonMap map[string]interface{}
-		err := json.Unmarshal(err_openapi_client.Body(), &jsonMap)
-		if err == nil {
-			return diag.Errorf(jsonMap["message"].(string))
-		}
-		return diag.Errorf(err_openapi_client.Error())
-	}
-
-	return diag.Errorf(err.Error())
+	return handleApiError(err, d, httpResp, false)
 }
 
 func HandleDBOpsApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
@@ -81,27 +38,69 @@ func HandleDBOpsApiError(err error, d *schema.ResourceData, httpResp *http.Respo
 }
 
 func HandleReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
-	erro, ok := err.(nextgen.GenericSwaggerError)
-	if ok {
-		if httpResp != nil && httpResp.StatusCode == 401 {
+	return handleApiError(err, d, httpResp, true)
+}
+
+func HandleDBOpsReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
+	_, ok := err.(dbops.GenericSwaggerError)
+	if ok && httpResp != nil {
+		if httpResp.StatusCode == 401 {
 			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
 				"1) Please check if token has expired or is wrong.\n" +
 				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
 		}
-		if httpResp != nil && httpResp.StatusCode == 403 {
+		if httpResp.StatusCode == 403 {
 			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
 				"1) Please check if the token has required permission for this operation.\n" +
 				"2) Please check if the token has expired or is wrong.")
 		}
-		if httpResp != nil && httpResp.StatusCode == 404 {
-			return diag.Errorf("resource with ID %s not found: %v", d.Id(), erro.Error())
-		}
-		if erro.Model() != nil && (erro.Code() == nextgen.ErrorCodes.ResourceNotFound || erro.Code() == nextgen.ErrorCodes.EntityNotFound) {
+		if httpResp.StatusCode == 404 {
 			d.SetId("")
 			d.MarkNewResource()
 			return nil
 		}
-		return diag.Errorf(erro.Error())
+	}
+	return diag.Errorf(err.Error())
+}
+
+func handleApiError(err error, d *schema.ResourceData, httpResp *http.Response, read bool) diag.Diagnostics {
+	erro, ok := err.(nextgen.GenericSwaggerError)
+	if ok {
+		errMessage := erro.Error()
+		gitopsErr, gitopsErrOk := erro.Model().(nextgen.GatewayruntimeError)
+		if gitopsErrOk {
+			errMessage = gitopsErr.Message
+		}
+
+		if httpResp != nil && httpResp.StatusCode == 401 {
+			return diag.Errorf("%s", httpResp.Status+"\n"+"Hint:\n"+
+				"1) Please check if token has expired or is wrong.\n"+
+				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
+		}
+		if httpResp != nil && httpResp.StatusCode == 403 {
+			return diag.Errorf("%s", httpResp.Status+"\n"+"Hint:\n"+
+				"1) Please check if the token has required permission for this operation.\n"+
+				"2) Please check if the token has expired or is wrong.")
+		}
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			// GitOps handling for NotFound
+			if gitopsErrOk && read {
+				if codes.Code(gitopsErr.Code) == codes.NotFound {
+					d.SetId("")
+					d.MarkNewResource()
+					return nil
+				}
+			}
+			return diag.Errorf("resource with ID %s not found: %v", d.Id(), errMessage)
+		}
+		if read {
+			if erro.Model() != nil && (erro.Code() == nextgen.ErrorCodes.ResourceNotFound || erro.Code() == nextgen.ErrorCodes.EntityNotFound) {
+				d.SetId("")
+				d.MarkNewResource()
+				return nil
+			}
+		}
+		return diag.Errorf(errMessage)
 	}
 
 	err_openapi_client, ok := err.(openapi_client_nextgen.GenericSwaggerError)
@@ -127,27 +126,5 @@ func HandleReadApiError(err error, d *schema.ResourceData, httpResp *http.Respon
 		return diag.Errorf(err_openapi_client.Error())
 	}
 
-	return diag.Errorf(err.Error())
-}
-
-func HandleDBOpsReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
-	_, ok := err.(dbops.GenericSwaggerError)
-	if ok && httpResp != nil {
-		if httpResp.StatusCode == 401 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if token has expired or is wrong.\n" +
-				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
-		}
-		if httpResp.StatusCode == 403 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if the token has required permission for this operation.\n" +
-				"2) Please check if the token has expired or is wrong.")
-		}
-		if httpResp.StatusCode == 404 {
-			d.SetId("")
-			d.MarkNewResource()
-			return nil
-		}
-	}
 	return diag.Errorf(err.Error())
 }

--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
 	openapi_client_nextgen "github.com/harness/harness-openapi-go-client/nextgen"
 	"google.golang.org/grpc/codes"

--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -67,7 +67,7 @@ func handleApiError(err error, d *schema.ResourceData, httpResp *http.Response, 
 			}
 			return diag.Errorf("resource with ID %s not found: %v", d.Id(), errMessage)
 		}
-		if read {
+		if read && !gitopsErrOk {
 			if erro.Model() != nil && (erro.Code() == nextgen.ErrorCodes.ResourceNotFound || erro.Code() == nextgen.ErrorCodes.EntityNotFound) {
 				d.SetId("")
 				d.MarkNewResource()

--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -1,13 +1,12 @@
 package helpers
 
 import (
-	"encoding/json"
+	"github.com/harness/harness-go-sdk/harness/nextgen"
+	openapi_client_nextgen "github.com/harness/harness-openapi-go-client/nextgen"
 	"google.golang.org/grpc/codes"
 	"net/http"
 
 	"github.com/harness/harness-go-sdk/harness/dbops"
-	"github.com/harness/harness-go-sdk/harness/nextgen"
-	openapi_client_nextgen "github.com/harness/harness-openapi-go-client/nextgen"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -34,32 +33,6 @@ func HandleDBOpsApiError(err error, d *schema.ResourceData, httpResp *http.Respo
 		}
 	}
 
-	return diag.Errorf(err.Error())
-}
-
-func HandleReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
-	return handleApiError(err, d, httpResp, true)
-}
-
-func HandleDBOpsReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
-	_, ok := err.(dbops.GenericSwaggerError)
-	if ok && httpResp != nil {
-		if httpResp.StatusCode == 401 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if token has expired or is wrong.\n" +
-				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
-		}
-		if httpResp.StatusCode == 403 {
-			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
-				"1) Please check if the token has required permission for this operation.\n" +
-				"2) Please check if the token has expired or is wrong.")
-		}
-		if httpResp.StatusCode == 404 {
-			d.SetId("")
-			d.MarkNewResource()
-			return nil
-		}
-	}
 	return diag.Errorf(err.Error())
 }
 
@@ -126,5 +99,31 @@ func handleApiError(err error, d *schema.ResourceData, httpResp *http.Response, 
 		return diag.Errorf(err_openapi_client.Error())
 	}
 
+	return diag.Errorf(err.Error())
+}
+
+func HandleReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
+	return handleApiError(err, d, httpResp, true)
+}
+
+func HandleDBOpsReadApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
+	_, ok := err.(dbops.GenericSwaggerError)
+	if ok && httpResp != nil {
+		if httpResp.StatusCode == 401 {
+			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
+				"1) Please check if token has expired or is wrong.\n" +
+				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
+		}
+		if httpResp.StatusCode == 403 {
+			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
+				"1) Please check if the token has required permission for this operation.\n" +
+				"2) Please check if the token has expired or is wrong.")
+		}
+		if httpResp.StatusCode == 404 {
+			d.SetId("")
+			d.MarkNewResource()
+			return nil
+		}
+	}
 	return diag.Errorf(err.Error())
 }

--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -51,6 +51,14 @@ func handleApiError(err error, d *schema.ResourceData, httpResp *http.Response, 
 				"1) Please check if token has expired or is wrong.\n"+
 				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
 		}
+		if gitopsErrOk && httpResp != nil && httpResp.StatusCode == 403 {
+			if len(errMessage) > 0 {
+				return diag.Errorf("%s", httpResp.Status+"\n"+"Hint:\n"+
+					"1) Please check if the token has required permission for this operation.\n"+
+					"2) Please check if the token has expired or is wrong.\n"+
+					"3) "+errMessage)
+			}
+		}
 		if httpResp != nil && httpResp.StatusCode == 403 {
 			return diag.Errorf("%s", httpResp.Status+"\n"+"Hint:\n"+
 				"1) Please check if the token has required permission for this operation.\n"+

--- a/internal/service/platform/gitops/agent/resource_gitops_agent.go
+++ b/internal/service/platform/gitops/agent/resource_gitops_agent.go
@@ -113,7 +113,7 @@ func resourceGitopsAgentCreate(ctx context.Context, d *schema.ResourceData, meta
 	resp, httpResp, err := c.AgentApi.AgentServiceForServerCreate(ctx, *createAgentRequest)
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 	// Soft delete lookup error handling
 	// https://harness.atlassian.net/browse/PL-23765

--- a/internal/service/platform/gitops/agent/resource_gitops_agent.go
+++ b/internal/service/platform/gitops/agent/resource_gitops_agent.go
@@ -155,9 +155,54 @@ func resourceGitopsAgentRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceGitopsAgentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 	ctx = context.WithValue(ctx, nextgen.ContextAccessToken, hh.EnvVars.BearerToken.Get())
+
+	var e diag.Diagnostics
+	if d.HasChange("identifier") {
+		oldValue, newValue := d.GetChange("identifier")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'identifier' cannot be updated after creation.")[0])
+		}
+		if err := d.Set("identifier", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("account_id") {
+		oldValue, newValue := d.GetChange("account_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")[0])
+		}
+		if err := d.Set("account_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("org_id") {
+		oldValue, newValue := d.GetChange("org_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")[0])
+		}
+		if err := d.Set("org_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("project_id") {
+		oldValue, newValue := d.GetChange("project_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")[0])
+		}
+		if err := d.Set("project_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(e) > 0 {
+		return e
+	}
+
 	agentIdentifier := d.Get("identifier").(string)
 	updateAgentRequest := buildCreateUpdateAgentRequest(d)
 	updateAgentRequest.AccountIdentifier = c.AccountId

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
@@ -65,7 +65,7 @@ func resourceGitopsAppProjectMappingCreate(ctx context.Context, d *schema.Resour
 	resp, httpResp, err := c.ProjectMappingsApi.AppProjectMappingServiceCreateV2(ctx, *createAppProjectMappingRequest, agentIdentifier)
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	if &resp == nil {

--- a/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
+++ b/internal/service/platform/gitops/app_project/resource_gitops_app_project_mapping.go
@@ -26,6 +26,7 @@ func ResourceGitopsAppProjectMapping() *schema.Resource {
 				Description: "Account identifier of the GitOps agent's Application Project.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"org_id": {
 				Description: "Organization identifier of the GitOps agent's Application Project.",
@@ -41,6 +42,7 @@ func ResourceGitopsAppProjectMapping() *schema.Resource {
 				Description: "Agent identifier for which the ArgoCD and Harness project mapping is to be created.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"identifier": {
 				Description: "Identifier of the GitOps Application Project.",
@@ -51,6 +53,7 @@ func ResourceGitopsAppProjectMapping() *schema.Resource {
 				Description: "ArgoCD Project name which is to be mapped to the Harness project.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 		},
 	}

--- a/internal/service/platform/gitops/applications/resource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/resource_gitops_applications.go
@@ -760,6 +760,22 @@ func resourceGitopsApplicationUpdate(ctx context.Context, d *schema.ResourceData
 	updateApplicationRequest := buildUpdateApplicationRequest(d)
 	var agentIdentifier, orgIdentifier, projectIdentifier, clusterIdentifier, repoIdentifier, appMetaDataName string
 	var skipRepoValidation bool
+
+	if d.HasChange("agent_id") {
+		return diag.Errorf("%s", "Field 'agent_id' cannot be updated after creation.")
+	}
+	if d.HasChange("account_id") {
+		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
+	}
+	if d.HasChange("account_id") {
+		return diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")
+	}
+	if d.HasChange("org_id") {
+		return diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")
+	}
+	if d.HasChange("project_id") {
+		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
+	}
 	if attr, ok := d.GetOk("agent_id"); ok {
 		agentIdentifier = attr.(string)
 	}

--- a/internal/service/platform/gitops/applications/resource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/resource_gitops_applications.go
@@ -776,6 +776,7 @@ func resourceGitopsApplicationUpdate(ctx context.Context, d *schema.ResourceData
 	if d.HasChange("project_id") {
 		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
 	}
+
 	if attr, ok := d.GetOk("agent_id"); ok {
 		agentIdentifier = attr.(string)
 	}

--- a/internal/service/platform/gitops/applications/resource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/resource_gitops_applications.go
@@ -740,7 +740,7 @@ func resourceGitopsApplicationRead(ctx context.Context, d *schema.ResourceData, 
 		QueryRepo: optional.NewString(repoIdentifier),
 	})
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	// Soft delete lookup error handling

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -420,7 +420,7 @@ func resourceGitopsClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	// Soft delete lookup error handling

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -26,30 +26,32 @@ func ResourceGitopsCluster() *schema.Resource {
 			"account_id": {
 				Description: "Account identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
+				ForceNew:    true,
 			},
 			"project_id": {
 				Description: "Project identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
+				ForceNew:    true,
 			},
 			"org_id": {
 				Description: "Organization identifier of the cluster.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
+				ForceNew:    true,
 			},
 			"agent_id": {
 				Description: "Agent identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"identifier": {
 				Description: "Identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"request": {
 				Description: "Cluster create or update request.",
@@ -441,26 +443,6 @@ func resourceGitopsClusterRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceGitopsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 	ctx = context.WithValue(ctx, nextgen.ContextAccessToken, hh.EnvVars.BearerToken.Get())
-
-	if d.HasChange("agent_id") {
-		return diag.Errorf("%s", "Field 'agent_id' cannot be updated after creation.")
-	}
-
-	if d.HasChange("account_id") {
-		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
-	}
-
-	if d.HasChange("account_id") {
-		return diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")
-	}
-
-	if d.HasChange("org_id") {
-		return diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")
-	}
-
-	if d.HasChange("project_id") {
-		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
-	}
 
 	agentIdentifier := d.Get("agent_id").(string)
 	identifier := d.Get("identifier").(string)

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -26,17 +26,20 @@ func ResourceGitopsCluster() *schema.Resource {
 			"account_id": {
 				Description: "Account identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 			},
 			"project_id": {
 				Description: "Project identifier of the GitOps cluster.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"org_id": {
 				Description: "Organization identifier of the cluster.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"agent_id": {
 				Description: "Agent identifier of the GitOps cluster.",
@@ -111,6 +114,7 @@ func ResourceGitopsCluster() *schema.Resource {
 												"bearer_token": {
 													Description: "Bearer authentication token the cluster.",
 													Type:        schema.TypeString,
+													Sensitive:   true,
 													Optional:    true,
 												},
 												"tls_client_config": {
@@ -435,9 +439,29 @@ func resourceGitopsClusterRead(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceGitopsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 	ctx = context.WithValue(ctx, nextgen.ContextAccessToken, hh.EnvVars.BearerToken.Get())
+
+	if d.HasChange("agent_id") {
+		return diag.Errorf("%s", "Field 'agent_id' cannot be updated after creation.")
+	}
+
+	if d.HasChange("account_id") {
+		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
+	}
+
+	if d.HasChange("account_id") {
+		return diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")
+	}
+
+	if d.HasChange("org_id") {
+		return diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")
+	}
+
+	if d.HasChange("project_id") {
+		return diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")
+	}
+
 	agentIdentifier := d.Get("agent_id").(string)
 	identifier := d.Get("identifier").(string)
 	updateClusterRequest := buildUpdateClusterRequest(d)

--- a/internal/service/platform/gitops/gnupg/resource_gnupg.go
+++ b/internal/service/platform/gitops/gnupg/resource_gnupg.go
@@ -164,7 +164,7 @@ func resourceGitopsGnupgRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	// Soft delete lookup error handling

--- a/internal/service/platform/gitops/project/resource_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/resource_gitops_app_project.go
@@ -21,24 +21,28 @@ func ResourceProject() *schema.Resource {
 		Importer:      helpers.GitopsAgentProjectImporter,
 		Schema: map[string]*schema.Schema{
 			"agent_id": {
-				Description: "Agent identifier of the GitOps project.",
+				Description: "Agent identifier of the GitOps project. Project is created on agent scope.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"account_id": {
-				Description: "Account identifier of the GitOps project.",
+				Description: "Account identifier of the GitOps project/agent.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"org_id": {
-				Description: "Org identifier of the GitOps project.",
+				Description: "Org identifier of the GitOps agent for which project is created.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			"project_id": {
-				Description: "Project identifier of the GitOps repository.",
+				Description: "Project identifier of the GitOps agent for which project is created.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			"query_name": {
 				Description: "Identifier for the GitOps project.",
@@ -47,7 +51,7 @@ func ResourceProject() *schema.Resource {
 				Computed:    true,
 			},
 			"upsert": {
-				Description: "Indicates if the GitOps repository should be updated if existing and inserted if not.",
+				Description: "Indicates if the GitOps project should be updated if existing and inserted if not.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
@@ -71,7 +75,7 @@ func ResourceProject() *schema.Resource {
 									"namespace": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: "Namespace of the GitOps project.",
+										Description: "Namespace of the GitOps project. This must match agent namespace.",
 									},
 									"resource_version": {
 										Type:        schema.TypeString,

--- a/internal/service/platform/gitops/project/resource_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/resource_gitops_app_project.go
@@ -588,7 +588,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 	// Soft delete lookup error handling
 	// https://harness.atlassian.net/browse/PL-23765

--- a/internal/service/platform/gitops/repository/data_source_gitops_repository.go
+++ b/internal/service/platform/gitops/repository/data_source_gitops_repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/harness/terraform-provider-harness/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceGitopsRepository() *schema.Resource {
@@ -94,10 +95,11 @@ func DataSourceGitopsRepository() *schema.Resource {
 							Optional:    true,
 						},
 						"type_": {
-							Description: "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
+							Description:  "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"git", "helm"}, false),
 						},
 						"name": {
 							Description: "Name to be used for this repo. Only used with Helm repos.",

--- a/internal/service/platform/gitops/repository/resource_gitops_repository.go
+++ b/internal/service/platform/gitops/repository/resource_gitops_repository.go
@@ -27,32 +27,31 @@ func ResourceGitopsRepositories() *schema.Resource {
 				Description: "Account identifier of the GitOps repository.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"project_id": {
 				Description: "Project identifier of the GitOps repository.",
 				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: func() (interface{}, error) {
-					return "", nil
-				},
+				Optional:    true,
+				ForceNew:    true,
 			},
 			"org_id": {
 				Description: "Organization identifier of the GitOps repository.",
 				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: func() (interface{}, error) {
-					return "", nil
-				},
+				Optional:    true,
+				ForceNew:    true,
 			},
 			"agent_id": {
 				Description: "Agent identifier of the GitOps repository.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"identifier": {
+				Description: "Identifier of the GitOps repository.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Identifier of the GitOps repository.",
+				ForceNew:    true,
 			},
 			"repo": {
 				Description: "Repo details holding application configurations.",
@@ -427,68 +426,6 @@ func resourceGitOpsRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 func resourceGitOpsRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 	var orgIdentifier, projectIdentifier, agentIdentifier, identifier string
-
-	var e diag.Diagnostics
-	if d.HasChange("identifier") {
-		oldValue, newValue := d.GetChange("identifier")
-		if oldValue != "" && oldValue != newValue {
-			e = append(e, diag.Errorf("%s", "Field 'identifier' cannot be updated after creation.")[0])
-		}
-
-		if err := d.Set("identifier", oldValue); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("agent_id") {
-		oldValue, newValue := d.GetChange("agent_id")
-		if oldValue != "" && oldValue != newValue {
-			e = append(e, diag.Errorf("%s", "Field 'agent_id' cannot be updated after creation.")[0])
-		}
-
-		if err := d.Set("agent_id", oldValue); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("account_id") {
-		oldValue, newValue := d.GetChange("account_id")
-		if oldValue != "" && oldValue != newValue {
-			e = append(e, diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")[0])
-		}
-
-		if err := d.Set("account_id", oldValue); err != nil {
-			return diag.FromErr(err)
-		}
-
-	}
-
-	if d.HasChange("org_id") {
-		oldValue, newValue := d.GetChange("org_id")
-		if oldValue != "" && oldValue != newValue {
-			e = append(e, diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")[0])
-		}
-
-		if err := d.Set("org_id", oldValue); err != nil {
-			return diag.FromErr(err)
-		}
-
-	}
-
-	if d.HasChange("project_id") {
-		oldValue, newValue := d.GetChange("project_id")
-		if oldValue != "" && oldValue != newValue {
-			e = append(e, diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")[0])
-		}
-
-		if err := d.Set("project_id", oldValue); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if len(e) > 0 {
-		return e
-	}
 
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)

--- a/internal/service/platform/gitops/repository/resource_gitops_repository.go
+++ b/internal/service/platform/gitops/repository/resource_gitops_repository.go
@@ -31,12 +31,18 @@ func ResourceGitopsRepositories() *schema.Resource {
 			"project_id": {
 				Description: "Project identifier of the GitOps repository.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
+				DefaultFunc: func() (interface{}, error) {
+					return "", nil
+				},
 			},
 			"org_id": {
 				Description: "Organization identifier of the GitOps repository.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
+				DefaultFunc: func() (interface{}, error) {
+					return "", nil
+				},
 			},
 			"agent_id": {
 				Description: "Agent identifier of the GitOps repository.",
@@ -44,9 +50,9 @@ func ResourceGitopsRepositories() *schema.Resource {
 				Required:    true,
 			},
 			"identifier": {
-				Description: "Identifier of the GitOps repository.",
 				Type:        schema.TypeString,
 				Required:    true,
+				Description: "Identifier of the GitOps repository.",
 			},
 			"repo": {
 				Description: "Repo details holding application configurations.",
@@ -421,6 +427,69 @@ func resourceGitOpsRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 func resourceGitOpsRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
 	var orgIdentifier, projectIdentifier, agentIdentifier, identifier string
+
+	var e diag.Diagnostics
+	if d.HasChange("identifier") {
+		oldValue, newValue := d.GetChange("identifier")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'identifier' cannot be updated after creation.")[0])
+		}
+
+		if err := d.Set("identifier", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("agent_id") {
+		oldValue, newValue := d.GetChange("agent_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'agent_id' cannot be updated after creation.")[0])
+		}
+
+		if err := d.Set("agent_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("account_id") {
+		oldValue, newValue := d.GetChange("account_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'account_id' cannot be updated after creation.")[0])
+		}
+
+		if err := d.Set("account_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+
+	}
+
+	if d.HasChange("org_id") {
+		oldValue, newValue := d.GetChange("org_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'org_id' cannot be updated after creation.")[0])
+		}
+
+		if err := d.Set("org_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+
+	}
+
+	if d.HasChange("project_id") {
+		oldValue, newValue := d.GetChange("project_id")
+		if oldValue != "" && oldValue != newValue {
+			e = append(e, diag.Errorf("%s", "Field 'project_id' cannot be updated after creation.")[0])
+		}
+
+		if err := d.Set("project_id", oldValue); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(e) > 0 {
+		return e
+	}
+
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -433,6 +502,7 @@ func resourceGitOpsRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 	if attr, ok := d.GetOk("identifier"); ok {
 		identifier = attr.(string)
 	}
+
 	updateRepoRequest := buildUpdateRepoRequest(d)
 	resp, httpResp, err := c.RepositoriesApiService.AgentRepositoryServiceUpdateRepository(ctx, updateRepoRequest, agentIdentifier, identifier, &nextgen.RepositoriesApiAgentRepositoryServiceUpdateRepositoryOpts{
 		AccountIdentifier: optional.NewString(c.AccountId),

--- a/internal/service/platform/gitops/repository/resource_gitops_repository.go
+++ b/internal/service/platform/gitops/repository/resource_gitops_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/antihax/optional"
 	hh "github.com/harness/harness-go-sdk/harness/helpers"
@@ -99,10 +100,11 @@ func ResourceGitopsRepositories() *schema.Resource {
 							Optional:    true,
 						},
 						"type_": {
-							Description: "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Computed:    true,
+							Description:  "Type specifies the type of the repo. Can be either \"git\" or \"helm. \"git\" is assumed if empty or absent.",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"git", "helm"}, false),
 						},
 						"name": {
 							Description: "Name to be used for this repo. Only used with Helm repos.",
@@ -402,7 +404,7 @@ func resourceGitOpsRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 	// Soft delete lookup error handling
 	// https://harness.atlassian.net/browse/PL-23765

--- a/internal/service/platform/gitops/repository_certificates/resource_gitops_repo_certs.go
+++ b/internal/service/platform/gitops/repository_certificates/resource_gitops_repo_certs.go
@@ -187,7 +187,7 @@ func resourceGitopsRepoCertsRead(ctx context.Context, d *schema.ResourceData, me
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	// Soft delete lookup error handling

--- a/internal/service/platform/gitops/repository_credentials/resource_gitops_repo_cred.go
+++ b/internal/service/platform/gitops/repository_credentials/resource_gitops_repo_cred.go
@@ -235,7 +235,7 @@ func resourceGitopsRepoCredRead(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 
 	// Soft delete lookup error handling


### PR DESCRIPTION
## Describe your changes

When resoruce is deleted outside the terraform flow it should get recreted on terraform apply if resoruce is still in the terraform state file.
Additionally making account, org, project, agent and identifier for repository, cluster and application as immutable fields, as these are not possible to change after creation.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
