### PR TITLE
fix: [PL-51691]: Added SERVICE_ACCOUNT as apikey_type for Org and Project level

### DIFF
--- a/docs/resources/platform_token.md
+++ b/docs/resources/platform_token.md
@@ -32,7 +32,7 @@ resource "harness_platform_token" "test" {
   parent_id   = "apikey_parent_id"
   account_id  = "account_id"
   org_id      = "org_id"
-  apikey_type = "USER"
+  apikey_type = "SERVICE_ACCOUNT"
   apikey_id   = "apikey_id"
 }
 
@@ -44,7 +44,7 @@ resource "harness_platform_token" "test" {
   account_id  = "account_id"
   org_id      = "org_id"
   project_id  = "project_id"
-  apikey_type = "USER"
+  apikey_type = "SERVICE_ACCOUNT"
   apikey_id   = "apikey_id"
 }
 ```

--- a/examples/resources/harness_platform_token/resource.tf
+++ b/examples/resources/harness_platform_token/resource.tf
@@ -15,7 +15,7 @@ resource "harness_platform_token" "test" {
   parent_id   = "apikey_parent_id"
   account_id  = "account_id"
   org_id      = "org_id"
-  apikey_type = "USER"
+  apikey_type = "SERVICE_ACCOUNT"
   apikey_id   = "apikey_id"
 }
 
@@ -27,6 +27,6 @@ resource "harness_platform_token" "test" {
   account_id  = "account_id"
   org_id      = "org_id"
   project_id  = "project_id"
-  apikey_type = "USER"
+  apikey_type = "SERVICE_ACCOUNT"
   apikey_id   = "apikey_id"
 }


### PR DESCRIPTION
## Describe your changes
At the Org and Project level, we cannot create USER `apikey_type` tokens. Fixed the documentation to reflect the same.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
