### PR TITLE
feat: [PL-56822]: Modified validation for Resource Group

### DIFF
--- a/internal/service/platform/resource_group/resource_group.go
+++ b/internal/service/platform/resource_group/resource_group.go
@@ -111,7 +111,7 @@ func ResourceResourceGroup() *schema.Resource {
 													Description:  "Name of the attribute. Valid values are `category` or `type`.",
 													Type:         schema.TypeString,
 													Optional:     true,
-													ValidateFunc: validation.StringInSlice([]string{"category", "type"}, false),
+													ValidateFunc: validation.StringInSlice([]string{"category", "type", "labels"}, false),
 												},
 												"attribute_values": {
 													Description: "Value of the attributes.Valid values for `category` are [ARTIFACTORY,CLOUD_COST,CLOUD_PROVIDER,CODE_REPO,MONITORING,SECRET_MANAGER,TICKETING] and for `type` are [Production,PreProduction]",


### PR DESCRIPTION
## Describe your changes
Modified validation for resource group for `attribute_name` field inside `resource_filter`. Testing done:
```
---[ REQUEST ]---------------------------------------
POST /resourcegroup/api/v2/resourcegroup?accountIdentifier=px7xd_BFRCi-pfWPYXVjvw HTTP/1.1
Host: qa.harness.io
User-Agent: terraform-provider-harness-platform-dev
Content-Length: 435
Accept: application/json
Content-Type: application/json
X-Api-Key: ****
Accept-Encoding: gzip

{
 "resourceGroup": {
  "accountIdentifier": "px7xd_BFRCi-pfWPYXVjvw",
  "identifier": "test_NIKE_FN_JG",
  "name": "RG Name FN JG",
  "tags": {
   "foo": "bar"
  },
  "description": "test",
  "allowedScopeLevels": [
   "account"
  ],
  "includedScopes": [
   {
    "filter": "EXCLUDING_CHILD_SCOPES",
    "accountIdentifier": "px7xd_BFRCi-pfWPYXVjvw"
   }
  ],
  "resourceFilter": {
   "resources": [
    {
     "resourceType": "GITOPS_APP",
     "attributeFilter": {
      "attributeName": "labels",
      "attributeValues": [
       "CLOUD_COST"
      ]
     }
    }
   ]
  }
 }
}

-------------------"
2024-09-06T18:26:38.347+0530 [WARN]  unexpected data: registry.terraform.io/harness/harness:stderr=----------------------------------
2024-09-06T18:26:39.522+0530 [WARN]  unexpected data: registry.terraform.io/harness/harness:stderr="2024-09-06 18:26:39 [DEBUG] harness-go-sdk harness-go-sdk API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Content-Length: 659
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
Content-Type: application/json;charset=utf-8
Date: Fri, 06 Sep 2024 12:56:39 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
Via: 1.1 google
X-Harness-Trace-Id: f8c4c5b94de277e8a567b3c3af3b9cc9

{
 "status": "SUCCESS",
 "data": {
  "resourceGroup": {
   "accountIdentifier": "px7xd_BFRCi-pfWPYXVjvw",
   "identifier": "test_NIKE_FN_JG",
   "name": "RG Name FN JG",
   "color": "#0063F7",
   "tags": {
    "foo": "bar"
   },
   "description": "test",
   "allowedScopeLevels": [
    "account"
   ],
   "includedScopes": [
    {
     "filter": "EXCLUDING_CHILD_SCOPES",
     "accountIdentifier": "px7xd_BFRCi-pfWPYXVjvw"
    }
   ],
   "resourceFilter": {
    "resources": [
     {
      "resourceType": "GITOPS_APP",
      "attributeFilter": {
       "attributeName": "lab"
2024-09-06T18:26:39.522+0530 [WARN]  unexpected data: registry.terraform.io/harness/harness:stderr="els",
       "attributeValues": [
        "CLOUD_COST"
       ]
      }
     }
    ],
    "includeAllResources": false
   }
  },
  "createdAt": 1725627399356,
  "lastModifiedAt": 1725627399356,
  "harnessManaged": false
 },
 "metaData": null,
 "correlationId": "f2178c1e-25eb-4862-ad67-5200b2aacc37"
}
-----------------------------------------------------"
2024-09-06T18:26:39.524+0530 [WARN]  Provider "provider[\"registry.terraform.io/harness/harness\"]" produced an unexpected new value for harness_platform_resource_group.test, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .org_id: was null, but now cty.StringVal("")
      - .project_id: was null, but now cty.StringVal("")
harness_platform_resource_group.test: Creation complete after 2s [id=test_NIKE_FN_JG]
2024-09-06T18:26:39.528+0530 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
2024-09-06T18:26:39.528+0530 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2024-09-06T18:26:39.530+0530 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/harness/harness/0.92.99/darwin_arm64/terraform-provider-harness pid=12240
2024-09-06T18:26:39.530+0530 [DEBUG] provider: plugin exited

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
