### PR TITLE
fix: [CDS-99032]: Removed the accountIdentifier

### DIFF
--- a/.changelog/1025.txt
+++ b/.changelog/1025.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+harness_platform_gitops_app_project: Fix the accountIdentifier context
+```

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project.go
@@ -77,7 +77,7 @@ func dataSourceProjectRead(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, &resp)
+	setProjectDetails(d, c.AccountId, &resp)
 
 	return nil
 }

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project.go
@@ -47,7 +47,10 @@ func DataSourceGitOpsProject() *schema.Resource {
 
 func dataSourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	var orgIdentifier, projectIdentifier, agentIdentifier, query_name string
+	var orgIdentifier, projectIdentifier, agentIdentifier, query_name, accountIdentifier string
+	if attr, ok := d.GetOk("account_id"); ok {
+		accountIdentifier = attr.(string)
+	}
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -62,7 +65,7 @@ func dataSourceProjectRead(ctx context.Context, d *schema.ResourceData, meta int
 		query_name = attr.(string)
 	}
 
-	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceGet(ctx, agentIdentifier, query_name, c.AccountId, &nextgen.ProjectsApiAgentProjectServiceGetOpts{
+	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceGet(ctx, agentIdentifier, query_name, accountIdentifier, &nextgen.ProjectsApiAgentProjectServiceGetOpts{
 		OrgIdentifier:     optional.NewString(orgIdentifier),
 		ProjectIdentifier: optional.NewString(projectIdentifier),
 	})

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project.go
@@ -80,7 +80,7 @@ func dataSourceProjectRead(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, c.AccountId, &resp)
+	setProjectDetails(d, accountIdentifier, &resp)
 
 	return nil
 }

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project.go
@@ -71,7 +71,7 @@ func dataSourceProjectRead(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
 	// Soft delete lookup error handling
 	// https://harness.atlassian.net/browse/PL-23765

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project_test.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project_test.go
@@ -2,6 +2,7 @@ package project_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/harness/terraform-provider-harness/internal/acctest"
@@ -10,8 +11,8 @@ import (
 
 func TestAccDataSourceGitopsProjectAccLevel(t *testing.T) {
 	resourceName := "harness_platform_gitops_app_project.test"
-	agentId := "rollouts"
-	accountId := "1bvyLackQK-Hapk25-Ry4w"
+	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.TestAccPreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/platform/gitops/project/data_source_gitops_app_project_test.go
+++ b/internal/service/platform/gitops/project/data_source_gitops_app_project_test.go
@@ -2,7 +2,6 @@ package project_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/harness/terraform-provider-harness/internal/acctest"
@@ -11,8 +10,8 @@ import (
 
 func TestAccDataSourceGitopsProjectAccLevel(t *testing.T) {
 	resourceName := "harness_platform_gitops_app_project.test"
-	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
-	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+	agentId := "rollouts"
+	accountId := "1bvyLackQK-Hapk25-Ry4w"
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.TestAccPreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,

--- a/internal/service/platform/gitops/project/resource_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/resource_gitops_app_project.go
@@ -518,7 +518,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, &resp)
+	setProjectDetails(d, c.AccountId, &resp)
 
 	return nil
 }
@@ -566,7 +566,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, &resp)
+	setProjectDetails(d, c.AccountId, &resp)
 
 	return nil
 }
@@ -601,7 +601,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, &resp)
+	setProjectDetails(d, c.AccountId, &resp)
 
 	return nil
 }
@@ -1347,8 +1347,9 @@ func createRequestBody(d *schema.ResourceData) nextgen.ProjectsProjectCreateRequ
 	return projectsProjectCreateRequest
 }
 
-func setProjectDetails(d *schema.ResourceData, projects *nextgen.AppprojectsAppProject) {
+func setProjectDetails(d *schema.ResourceData, account_id string, projects *nextgen.AppprojectsAppProject) {
 	d.SetId(projects.Metadata.Name)
+	d.Set("account_id", account_id)
 	projectList := []interface{}{}
 	project := map[string]interface{}{}
 	if projects.Metadata != nil {

--- a/internal/service/platform/gitops/project/resource_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/resource_gitops_app_project.go
@@ -484,8 +484,11 @@ func ResourceProject() *schema.Resource {
 
 func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	var orgIdentifier, projectIdentifier, agentIdentifier string
+	var orgIdentifier, projectIdentifier, agentIdentifier, accountIdentifier string
 	var upsert bool
+	if attr, ok := d.GetOk("account_id"); ok {
+		accountIdentifier = attr.(string)
+	}
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -503,7 +506,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 	projectData := createRequestBody(d)
 	projectData.Upsert = upsert
 
-	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceCreate(ctx, projectData, c.AccountId, agentIdentifier, &nextgen.ProjectsApiAgentProjectServiceCreateOpts{
+	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceCreate(ctx, projectData, accountIdentifier, agentIdentifier, &nextgen.ProjectsApiAgentProjectServiceCreateOpts{
 		OrgIdentifier:     optional.NewString(orgIdentifier),
 		ProjectIdentifier: optional.NewString(projectIdentifier),
 	})
@@ -518,14 +521,17 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, c.AccountId, &resp)
+	setProjectDetails(d, accountIdentifier, &resp)
 
 	return nil
 }
 
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	var orgIdentifier, projectIdentifier, agentIdentifier, query_name string
+	var orgIdentifier, projectIdentifier, agentIdentifier, query_name, accountIdentifier string
+	if attr, ok := d.GetOk("account_id"); ok {
+		accountIdentifier = attr.(string)
+	}
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -551,29 +557,31 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceGet(ctx, agentIdentifier, query_name, c.AccountId, &nextgen.ProjectsApiAgentProjectServiceGetOpts{
+	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceGet(ctx, agentIdentifier, query_name, accountIdentifier, &nextgen.ProjectsApiAgentProjectServiceGetOpts{
 		OrgIdentifier:     optional.NewString(orgIdentifier),
 		ProjectIdentifier: optional.NewString(projectIdentifier),
 	})
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandleReadApiError(err, d, httpResp)
 	}
-	// Soft delete lookup error handling
-	// https://harness.atlassian.net/browse/PL-23765
-	if resp.Metadata == nil {
+
+	if &resp == nil {
 		d.SetId("")
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, c.AccountId, &resp)
+	setProjectDetails(d, accountIdentifier, &resp)
 
 	return nil
 }
 
 func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	var orgIdentifier, projectIdentifier, agentIdentifier string
+	var orgIdentifier, projectIdentifier, agentIdentifier, accountIdentifier string
+	if attr, ok := d.GetOk("account_id"); ok {
+		accountIdentifier = attr.(string)
+	}
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -586,7 +594,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	projectData := updateRequestBody(d)
 
-	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceUpdate(ctx, projectData, c.AccountId, agentIdentifier, projectData.Project.Metadata.Name, &nextgen.ProjectsApiAgentProjectServiceUpdateOpts{
+	resp, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceUpdate(ctx, projectData, accountIdentifier, agentIdentifier, projectData.Project.Metadata.Name, &nextgen.ProjectsApiAgentProjectServiceUpdateOpts{
 		OrgIdentifier:     optional.NewString(orgIdentifier),
 		ProjectIdentifier: optional.NewString(projectIdentifier),
 	})
@@ -601,14 +609,17 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		d.MarkNewResource()
 		return nil
 	}
-	setProjectDetails(d, c.AccountId, &resp)
+	setProjectDetails(d, accountIdentifier, &resp)
 
 	return nil
 }
 
 func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, ctx := meta.(*internal.Session).GetPlatformClientWithContext(ctx)
-	var orgIdentifier, projectIdentifier, agentIdentifier, query_name string
+	var orgIdentifier, projectIdentifier, agentIdentifier, query_name, accountIdentifier string
+	if attr, ok := d.GetOk("account_id"); ok {
+		accountIdentifier = attr.(string)
+	}
 	if attr, ok := d.GetOk("org_id"); ok {
 		orgIdentifier = attr.(string)
 	}
@@ -630,7 +641,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	_, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceDelete(ctx, agentIdentifier, query_name, c.AccountId, orgIdentifier, &nextgen.ProjectsApiAgentProjectServiceDeleteOpts{
+	_, httpResp, err := c.ProjectGitOpsApi.AgentProjectServiceDelete(ctx, agentIdentifier, query_name, accountIdentifier, orgIdentifier, &nextgen.ProjectsApiAgentProjectServiceDeleteOpts{
 		ProjectIdentifier: optional.NewString(projectIdentifier),
 	})
 
@@ -1395,17 +1406,33 @@ func setProjectDetails(d *schema.ResourceData, account_id string, projects *next
 		spec["source_repos"] = sourceRepoList
 		clusterResourceWhitelist := []interface{}{}
 		clusterResourceWhite := map[string]interface{}{}
-		clusterResourceWhite["group"] = projects.Spec.ClusterResourceWhitelist[0].Group
-		clusterResourceWhite["kind"] = projects.Spec.ClusterResourceWhitelist[0].Kind
-		clusterResourceWhitelist = append(clusterResourceWhitelist, clusterResourceWhite)
-		spec["cluster_resource_whitelist"] = clusterResourceWhitelist
+		if len(projects.Spec.ClusterResourceWhitelist) > 0 {
+			clusterResourceWhite["group"] = projects.Spec.ClusterResourceWhitelist[0].Group
+			clusterResourceWhite["kind"] = projects.Spec.ClusterResourceWhitelist[0].Kind
+		}
+		if len(clusterResourceWhite) > 0 {
+			clusterResourceWhitelist = append(clusterResourceWhitelist, clusterResourceWhite)
+		}
+		if len(clusterResourceWhitelist) > 0 {
+			spec["cluster_resource_whitelist"] = clusterResourceWhitelist
+		}
+
 		destinationList := []interface{}{}
 		destination := map[string]interface{}{}
-		destination["namespace"] = projects.Spec.Destinations[0].Namespace
-		destination["server"] = projects.Spec.Destinations[0].Server
-		destination["name"] = projects.Spec.Destinations[0].Name
-		destinationList = append(destinationList, destination)
-		spec["destinations"] = destinationList
+		if len(projects.Spec.Destinations) > 0 {
+			destination["namespace"] = projects.Spec.Destinations[0].Namespace
+			destination["server"] = projects.Spec.Destinations[0].Server
+			destination["name"] = projects.Spec.Destinations[0].Name
+		}
+
+		if len(destination) > 0 {
+			destinationList = append(destinationList, destination)
+		}
+
+		if len(destinationList) > 0 {
+			spec["destinations"] = destinationList
+		}
+
 		orphanList := []interface{}{}
 		orphan := map[string]interface{}{}
 		orphan["warn"] = projects.Spec.OrphanedResources.Warn

--- a/internal/service/platform/gitops/project/resource_gitops_app_project.go
+++ b/internal/service/platform/gitops/project/resource_gitops_app_project.go
@@ -1349,7 +1349,6 @@ func createRequestBody(d *schema.ResourceData) nextgen.ProjectsProjectCreateRequ
 
 func setProjectDetails(d *schema.ResourceData, projects *nextgen.AppprojectsAppProject) {
 	d.SetId(projects.Metadata.Name)
-	d.Set("account_id", "1bvyLackQK-Hapk25-Ry4w")
 	projectList := []interface{}{}
 	project := map[string]interface{}{}
 	if projects.Metadata != nil {


### PR DESCRIPTION
## Describe your changes
Verified the below scenarios

- teraform apply ( create new one )
- terraform apply ( reruning terraform apply after creating )
- remove project from namespace and rerun it should get create
- terraform apply update ( some of the fields of project itseld )
- terrfaofmr apply rerun ufter update
- try to update some of the fields agent_id, org_id, account_id ( it should be recreated)
- rerun terraform apply after update ( nothing should change )
- remove project from terrafrom resource file and run terraform apply
- rerun terraform apply

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
