### PR TITLE
fix: [PL-57016]: Setting user_emails only if users is not set in read user group v2

### DIFF
--- a/internal/service/platform/usergroup/usergroup.go
+++ b/internal/service/platform/usergroup/usergroup.go
@@ -430,7 +430,9 @@ func readUserGroupV2(d *schema.ResourceData, env *nextgen.UserGroupResponseV2, u
 	d.Set("name", env.Name)
 	d.Set("description", env.Description)
 	d.Set("tags", helpers.FlattenTags(env.Tags))
-	d.Set("user_emails", ignoreOrderIfAllElementsMatch(user_emails, flattenUserInfo(env.Users)))
+	if _, ok := d.GetOk("users"); !ok {
+		d.Set("user_emails", ignoreOrderIfAllElementsMatch(user_emails, flattenUserInfo(env.Users)))
+	}
 	d.Set("notification_configs", flattenNotificationConfig(env.NotificationConfigs))
 	d.Set("linked_sso_id", env.LinkedSsoId)
 	d.Set("linked_sso_display_name", env.LinkedSsoDisplayName)


### PR DESCRIPTION
## Describe your changes
Setting user_emails only if users is not set in read user group v2. Currently, we support user groups management using 2 variables, either `users` (user IDs) or `user_emails` (user emails). If `users` field is already set, we do not want to set `user_emails`. Due to this, on `terraform plan`, even if there are no changes, it shows a diff because we are setting `user_emails` for a resource where `users` is being used. Testing done:
```
1. Create new resource:
	a. Using user_emails
	b. Using users (user IDs)
2. Update existing resource
	a. Using user_emails
	b. Using users (user IDs)
3. Read existing resource
	a. Using user_emails
	b. Using users (user IDs)
4. Delete existing resource
	a. Using user_emails
	b. Using users (user IDs)
5. Import existing resource

```

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
