### PR TITLE
Update secret.go

### DIFF
--- a/internal/service/platform/secret/secret.go
+++ b/internal/service/platform/secret/secret.go
@@ -133,6 +133,7 @@ func readCommonSecretData(d *schema.ResourceData, secret *nextgen.Secret) {
 	d.Set("identifier", secret.Identifier)
 	d.Set("description", secret.Description)
 	d.Set("name", secret.Name)
+	d.Set("value", secret.Value)
 	d.Set("org_id", secret.OrgIdentifier)
 	d.Set("project_id", secret.ProjectIdentifier)
 	d.Set("tags", helpers.FlattenTags(secret.Tags))


### PR DESCRIPTION
**Title:** Feat: Return secret value in terraform data source

**Summary:**
secret value needs to be read in order to create gitops clusters or connectors through terraform avoiding setting or passing this sensitive value through tfvars files and since those secrets can be stored beforehand in harness secrets, it can be read and used for harness resources creation

