### PR TITLE
Fix: [PIPE-21769]: Import Policies to Terraform fix

### DIFF
--- a/.changelog/1028.txt
+++ b/.changelog/1028.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+harness_platform_policy: Fixed the import logic.
+```

--- a/docs/resources/platform_policy.md
+++ b/docs/resources/platform_policy.md
@@ -86,6 +86,10 @@ REGO
 Import is supported using the following syntax:
 
 ```shell
-# Import using the organization id
-terraform import harness_platform_policy.example <organization_id>
+# Import account level policy
+terraform import harness_platform_policy.example <policy_id>
+# Import org level policy
+terraform import harness_platform_policy.example <org_id>/<policy_id>
+# Import proj level policy
+terraform import harness_platform_policy.example <org_id>/<project_id>/<policy_id>
 ```

--- a/internal/service/platform/policy/resource_policy.go
+++ b/internal/service/platform/policy/resource_policy.go
@@ -20,7 +20,7 @@ func ResourcePolicy() *schema.Resource {
 		UpdateContext: resourcePolicyCreateOrUpdate,
 		DeleteContext: resourcePolicyDelete,
 		CreateContext: resourcePolicyCreateOrUpdate,
-		Importer:      helpers.OrgResourceImporter,
+		Importer:      helpers.MultiLevelResourceImporter,
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/internal/service/platform/policy/resource_policy_test.go
+++ b/internal/service/platform/policy/resource_policy_test.go
@@ -80,6 +80,13 @@ func TestAccResourcePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rego", updatedRego),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       acctest.ProjectResourceImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"description", "git_base_branch", "git_branch", "git_commit_msg", "git_import", "git_is_new_branch"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
**Title:** [Component/Feature] Import Policies to Terraform fix

**Summary:**
Import Policies to Terraform fix

**Details:**
I updated the helper that was being used for the import function. 
Earlier it was OrgResourceImporter [which potentially means that we can only import org level resources] only now updated to MultiLevelResourceImporter.

**Related Issues:**
https://harness.atlassian.net/browse/PIPE-21769

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [x] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
