### PR TITLE
[Docs]: Clarified usage of parent_identifier for root-level entries in Harness File Store

### DIFF
--- a/docs/resources/platform_file_store_file.md
+++ b/docs/resources/platform_file_store_file.md
@@ -35,7 +35,8 @@ resource "harness_platform_file_store_file" "example" {
 
 - `identifier` (String) Unique identifier of the resource.
 - `name` (String) Name of the resource.
-- `parent_identifier` (String) File parent identifier on Harness File Store
+- `parent_identifier` (String) File parent identifier on Harness File Store. If the folder is at the root level, the parent_identifier will be `Root`.
+
 
 ### Optional
 

--- a/docs/resources/platform_file_store_folder.md
+++ b/docs/resources/platform_file_store_folder.md
@@ -32,7 +32,7 @@ resource "harness_platform_file_store_folder" "example" {
 
 - `identifier` (String) Unique identifier of the resource.
 - `name` (String) Name of the resource.
-- `parent_identifier` (String) Folder parent identifier on Harness File Store
+- `parent_identifier` (String) Folder parent identifier on Harness File Store. If the file is at the root level, the parent_identifier will be `Root`.
 
 ### Optional
 


### PR DESCRIPTION
### Title:
Clarified `parent_identifier` usage for root-level entries in Harness File Store

### Description:
This PR updates the documentation to clearly state that the `parent_identifier` for root-level folders and files in the Harness File Store is `Root`. This change ensures better understanding of how root-level identifiers are handled in the file store.

### Changes made:
Updated descriptions for parent_identifier in both folder and file contexts to specify that the root-level identifier is `Root`.
Fixed Issue #1047 


## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
