### PR TITLE
[Docs]: Add missing slash separators in file and folder import syntax

### DIFF
--- a/docs/resources/platform_file_store_file.md
+++ b/docs/resources/platform_file_store_file.md
@@ -83,8 +83,8 @@ Import is supported using the following syntax:
 terraform import harness_platform_file_store_file.example <identifier>
 
 # Import org level file
-terraform import harness_platform_file_store_file.example <org_id><identifier>
+terraform import harness_platform_file_store_file.example <org_id>/<identifier>
 
 # Import org level file
-terraform import harness_platform_file_store_file.example <org_id><project_id><identifier>
+terraform import harness_platform_file_store_file.example <org_id>/<project_id>/<identifier>
 ```

--- a/docs/resources/platform_file_store_folder.md
+++ b/docs/resources/platform_file_store_folder.md
@@ -75,8 +75,8 @@ Import is supported using the following syntax:
 terraform import harness_platform_file_store_folder.example <identifier>
 
 # Import org level folder
-terraform import harness_platform_file_store_folder.example <org_id><identifier>
+terraform import harness_platform_file_store_folder.example <org_id>/<identifier>
 
 # Import org level folder
-terraform import harness_platform_file_store_folder.example <org_id><project_id><identifier>
+terraform import harness_platform_file_store_folder.example <org_id>/<project_id>/<identifier>
 ```

--- a/examples/resources/harness_platform_file_store_file/import.sh
+++ b/examples/resources/harness_platform_file_store_file/import.sh
@@ -2,7 +2,7 @@
 terraform import harness_platform_file_store_file.example <identifier>
 
 # Import org level file
-terraform import harness_platform_file_store_file.example <org_id><identifier>
+terraform import harness_platform_file_store_file.example <org_id>/<identifier>
 
 # Import org level file
-terraform import harness_platform_file_store_file.example <org_id><project_id><identifier>
+terraform import harness_platform_file_store_file.example <org_id>/<project_id>/<identifier>

--- a/examples/resources/harness_platform_file_store_folder/import.sh
+++ b/examples/resources/harness_platform_file_store_folder/import.sh
@@ -2,7 +2,7 @@
 terraform import harness_platform_file_store_folder.example <identifier>
 
 # Import org level folder
-terraform import harness_platform_file_store_folder.example <org_id><identifier>
+terraform import harness_platform_file_store_folder.example <org_id>/<identifier>
 
 # Import org level folder
-terraform import harness_platform_file_store_folder.example <org_id><project_id><identifier>
+terraform import harness_platform_file_store_folder.example <org_id>/<project_id>/<identifier>


### PR DESCRIPTION
**Title:** Add missing slash separators in file and folder import syntax

**Description:**
This PR addresses an issue where the documentation for file and folder import syntax lacked proper slash separators. Adding these separators ensures clarity and accuracy when referencing file paths during import processes.

**Changes made:**
Updated the file and folder import examples to include the correct slash separators.
Fixed Issue #1016 

**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [x] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
