### PR TITLE
fix: [PL-57535]: Fixed a bug to allow userIds to be imported during terraform import

### DIFF
--- a/internal/service/platform/usergroup/usergroup.go
+++ b/internal/service/platform/usergroup/usergroup.go
@@ -176,7 +176,8 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	attr1 := resp.Data.SsoLinked
 
-	if attr, ok := d.GetOk("users"); ok && !attr1 {
+	attr := resp.Data.Users
+	if attr != nil && !attr1 {
 		d.Set("users", attr)
 	} else if attr1 {
 		d.Set("users", []string{})


### PR DESCRIPTION
**Title:** Fixed a bug to allow userIds to be imported during terraform import

**Summary:**
This PR fixes a bug in the read context of user group resource.
Current behaviour - "userIds" from the Rest API response are not being read while comparing remote and local state of user groups.
Fixed behaviour - "userIds" will be read from the Rest API response while comparing changes to make via terraform, as well as while importing as resource to terraform state.

Testing-
1. Verified that "terraform import" command imports userIds.
2. Verified that "terraform plan" and "terraform apply" commands compare the userIds in the configuration file with the server-side state of the user-group.
3. CRUD with User IDs
4. CRUD with User emails
5. Creation with User IDs and then changing user emails field and removing User ID field
6. Creation with User emails field and then changing user IDs field and removing User emails field
7. Adding/Deleting user directly on server and doing tf plan for both cases, once using email and once using ID of users

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
