### PR TITLE
fix:[PIPE-22127] Forced pause to prevent duplicate webhook creation

### DIFF
--- a/internal/service/pipeline/triggers/resource_triggers.go
+++ b/internal/service/pipeline/triggers/resource_triggers.go
@@ -3,6 +3,7 @@ package triggers
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/antihax/optional"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
@@ -89,6 +90,8 @@ func resourceTriggersCreateOrUpdate(ctx context.Context, d *schema.ResourceData,
 			d.Get("target_id").(string), &nextgen.TriggersApiCreateTriggerOpts{
 				WithServiceV2: optional.NewBool(true),
 			})
+		// A FORCED PAUSE TO PREVENT DUPLICATE WEBHOOK CREATION.
+		time.Sleep(5 * time.Second)
 	} else {
 		resp, httpResp, err = c.TriggersApi.UpdateTrigger(ctx, d.Get("yaml").(string), c.AccountId, d.Get("org_id").(string),
 			d.Get("project_id").(string),


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change

**Summary:**
In the backend, two different threads are handling the webhook creation.

Since the workaround involves adding a delay between trigger resource creations, a potential quick-win could be to introduce a short pause or ‘hiccup’ within our Terraform provider, as this issue is only impacting it.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
