### PR TITLE
fix: [CDS-104757]: set account_id if present in agent read response e…

### DIFF
--- a/.changelog/1132.txt
+++ b/.changelog/1132.txt
@@ -1,0 +1,4 @@
+```release-note:fix account_id becoming null in platform_gitops_agent after deprecation
+platform_gitops_agent: there was a deprecation of account_id in all harness gitops resources. this introduced a bug in agent resource where
+it was not being set at all after it was changed to computed: true.
+```

--- a/internal/service/platform/gitops/agent/resource_gitops_agent.go
+++ b/internal/service/platform/gitops/agent/resource_gitops_agent.go
@@ -319,6 +319,7 @@ func buildCreateAgentRequest(d *schema.ResourceData) *nextgen.V1Agent {
 
 func readAgent(d *schema.ResourceData, agent *nextgen.V1Agent) {
 	d.SetId(agent.Identifier)
+	d.Set("account_id", agent.AccountIdentifier)
 	d.Set("identifier", agent.Identifier)
 	d.Set("name", agent.Name)
 	d.Set("description", agent.Description)


### PR DESCRIPTION
…ven though its deprecated

**Title:** [Component/Feature] Short Description of the Change

**Summary:**
Provide a brief overview of what the PR does and why it is needed.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
