### PR TITLE
fix: [CDS-104942]: added support for optional field

### DIFF
--- a/internal/service/cd_nextgen/connector/cloudProviders/gcp.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/gcp.go
@@ -123,7 +123,7 @@ func ResourceConnectorGcp() *schema.Resource {
 						"delegate_selectors": {
 							Description: "The delegates to inherit the credentials from.",
 							Type:        schema.TypeSet,
-							Required:    true,
+							Optional:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 					},


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change
This PR resolves the issue faced my customer as mentioned in the ticket: https://harness.atlassian.net/browse/CDS-104942

**Summary:**
Provide a brief overview of what the PR does and why it is needed.
In the case of GCP even when the **execute_on_delegate** was set to False, to setup GCP Connector delegate was mandatorily required which is not the expected case.

**Details:**
Explain the changes in detail, including any relevant context or background information.
To resolve the issue we have replaced **Required** with **Optional** field marked as true due to which delegate selection is mandatory.

![Uploading Screenshot 2024-12-10 at 4.14.24 PM.png…]()


**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
