### PR TITLE
fix: [CDS-105224]: Add user-friendly message when service is not found

### DIFF
--- a/internal/service/cd_nextgen/service/data_source_service.go
+++ b/internal/service/cd_nextgen/service/data_source_service.go
@@ -80,6 +80,9 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 			Branch:                 helpers.BuildField(d, "git_details.0.branch"),
 			LoadFromFallbackBranch: helpers.BuildFieldBool(d, "git_details.0.load_from_fallback_branch"),
 		})
+		if err != nil {
+			return helpers.HandleApiError(err, d, httpResp)
+		}
 		svc = resp.Data.Service
 	} else if name != "" {
 		svc, httpResp, err = c.ServicesApi.GetServiceByName(ctx, c.AccountId, name, nextgen.GetServiceByNameOpts{


### PR DESCRIPTION
**Title:**
[data/service] Add user-friendly message when service is not found

**Summary:**
Terraform should show an error message stating that the service could not be found.

**Details:**
<img width="880" alt="Screenshot 2024-12-18 at 16 35 09" src="https://github.com/user-attachments/assets/2fabf57f-3c0b-4278-8d3d-71e8d8543a4f" />

**Related Issues:**
[Reference any related issues or tickets ](https://harness.atlassian.net/browse/CDS-105224)

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
