### PR TITLE
fix: [CDS-105417]: harness_platform_gitops_applications resource is n…

### DIFF
--- a/internal/service/platform/gitops/applications/datasource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/datasource_gitops_applications.go
@@ -1108,6 +1108,9 @@ func datasourceGitopsApplicationRead(ctx context.Context, d *schema.ResourceData
 		d.MarkNewResource()
 		return nil
 	}
-	setApplication(d, &resp)
+	err = setApplication(d, &resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }

--- a/internal/service/platform/gitops/applications/resource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/resource_gitops_applications.go
@@ -1137,7 +1137,11 @@ func resourceGitopsApplicationCreate(ctx context.Context, d *schema.ResourceData
 		d.MarkNewResource()
 		return nil
 	}
-	setApplication(d, &resp)
+	err = setApplication(d, &resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -1176,7 +1180,11 @@ func resourceGitopsApplicationRead(ctx context.Context, d *schema.ResourceData, 
 		d.MarkNewResource()
 		return nil
 	}
-	setApplication(d, &resp)
+	err = setApplication(d, &resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -1279,7 +1287,11 @@ func resourceGitopsApplicationUpdate(ctx context.Context, d *schema.ResourceData
 		d.MarkNewResource()
 		return nil
 	}
-	setApplication(d, &resp)
+	err = setApplication(d, &resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -1324,7 +1336,7 @@ func resourceGitopsApplicationDelete(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func setApplication(d *schema.ResourceData, app *nextgen.Servicev1Application) {
+func setApplication(d *schema.ResourceData, app *nextgen.Servicev1Application) error {
 	d.SetId(app.Name)
 	d.Set("org_id", app.OrgIdentifier)
 	d.Set("project_id", app.ProjectIdentifier)
@@ -1441,9 +1453,13 @@ func setApplication(d *schema.ResourceData, app *nextgen.Servicev1Application) {
 			application["spec"] = specList
 		}
 		applicationList = append(applicationList, application)
-		d.Set("application", applicationList)
-	}
 
+		err := d.Set("application", applicationList)
+		if err != nil {
+			return fmt.Errorf("error setting application: %v", err)
+		}
+	}
+	return nil
 }
 
 func buildCreateApplicationRequest(d *schema.ResourceData) nextgen.ApplicationsApplicationCreateRequest {
@@ -1644,7 +1660,6 @@ func getSourceForState(appSpec *nextgen.ApplicationsApplicationSpec) map[string]
 	source["path"] = appSpec.Source.Path
 	source["target_revision"] = appSpec.Source.TargetRevision
 	source["chart"] = appSpec.Source.Chart
-	source["ref"] = appSpec.Source.Ref
 	if appSpec.Source.Helm != nil {
 		var helmList = []interface{}{}
 		var helm = map[string]interface{}{}


### PR DESCRIPTION
…ot detecting drift in application manifest

**Title:** [Component/Feature] Short Description of the Change

Fix harness_platform_gitops_applications resource is not detecting drift in application manifest.

**Summary:**
Provide a brief overview of what the PR does and why it is needed.

Issue - harness_platform_gitops_applications resource is not detecting drift in application manifest.
Root cause - ref for sources was being set which is not part of the schema. ref is only used for multisource sources.
Fix - skip setting ref for app source

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
