### PR TITLE
feat: [CDS-105527] Add page and size for service list datasource

### DIFF
--- a/helpers/schema.go
+++ b/helpers/schema.go
@@ -200,6 +200,13 @@ func BuildField(d *schema.ResourceData, field string) optional.String {
 	return optional.EmptyString()
 }
 
+func BuildFieldInt32(d *schema.ResourceData, field string) optional.Int32 {
+	if arr, ok := d.GetOk(field); ok {
+		return optional.NewInt32(int32(arr.(int)))
+	}
+	return optional.EmptyInt32()
+}
+
 func BuildFieldForBoolean(d *schema.ResourceData, field string) optional.Bool {
 	if arr, ok := d.GetOk(field); ok {
 

--- a/helpers/schema_test.go
+++ b/helpers/schema_test.go
@@ -1,0 +1,46 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildFieldForInt32_Int(t *testing.T) {
+
+	var value = 14
+	expected := optional.NewInt32(int32(value))
+
+	resource := createTestResourceForBuildField()
+	data := map[string]interface{}{
+		"field_int": value,
+	}
+
+	d := schema.TestResourceDataRaw(t, resource.Schema, data)
+
+	assert.Equal(t, expected, BuildFieldInt32(d, "field_int"))
+}
+
+func TestBuildFieldForInt32_Missing(t *testing.T) {
+
+	expected := optional.EmptyInt32()
+
+	resource := createTestResourceForBuildField()
+	data := map[string]interface{}{}
+
+	d := schema.TestResourceDataRaw(t, resource.Schema, data)
+
+	assert.Equal(t, expected, BuildFieldInt32(d, "field_int"))
+}
+
+func createTestResourceForBuildField() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"field_int": {
+				Type: schema.TypeInt,
+			},
+		},
+	}
+}

--- a/internal/service/cd_nextgen/service/data_source_service_list.go
+++ b/internal/service/cd_nextgen/service/data_source_service_list.go
@@ -34,6 +34,16 @@ func DataSourceServiceList() *schema.Resource {
 					},
 				},
 			},
+			"page": {
+				Description: "Page index of the results to fetch. Default: 0",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"size": {
+				Description: "Results per page. Default: 100; Max: 1000",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
 		},
 	}
 
@@ -52,6 +62,8 @@ func dataSourceServiceListRead(ctx context.Context, d *schema.ResourceData, meta
 	resp, httpResp, err = c.ServicesApi.GetServiceList(ctx, c.AccountId, &nextgen.ServicesApiGetServiceListOpts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
+		Page:              helpers.BuildFieldInt32(d, "page"),
+		Size:              helpers.BuildFieldInt32(d, "size"),
 	})
 	var output []nextgen.ServiceResponse = resp.Data.Content
 	var services []map[string]interface{}


### PR DESCRIPTION
**Title:**
Add page and size for service list datasource

**Summary:**
This PR enhances the Terraform provider by adding support for pagination to the service_list datasource. Two new parameters, page and size, have been introduced, allowing users to control the pagination of results when querying services.

**Details:**
N/A

**Related Issues:**
* [CDS-105527](https://harness.atlassian.net/browse/CDS-105527)

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`


[CDS-105527]: https://harness.atlassian.net/browse/CDS-105527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ