### PR TITLE
Fix:[IMPENG-324]: added execute_on_delagte param support.

### DIFF
--- a/.changelog/1032.txt
+++ b/.changelog/1032.txt
@@ -1,0 +1,4 @@
+```relese-note:fix
+harness_platform_connector_aws: Added Support for execute_on_delegate param.
+harness_platform_connector_azure_cloud_provider: Added Support for execute_on_delegate param.
+```

--- a/docs/data-sources/platform_connector_aws.md
+++ b/docs/data-sources/platform_connector_aws.md
@@ -36,6 +36,7 @@ data "harness_platform_connector_aws" "example" {
 - `cross_account_access` (List of Object) Select this option if you want to use one AWS account for the connection, but you want to deploy or build in a different AWS account. In this scenario, the AWS account used for AWS access in Credentials will assume the IAM role you specify in Cross-account role ARN setting. This option uses the AWS Security Token Service (STS) feature. (see [below for nested schema](#nestedatt--cross_account_access))
 - `description` (String) Description of the resource.
 - `equal_jitter_backoff_strategy` (List of Object) Equal Jitter BackOff Strategy. (see [below for nested schema](#nestedatt--equal_jitter_backoff_strategy))
+- `execute_on_delegate` (Boolean) Execute on delegate or not.
 - `fixed_delay_backoff_strategy` (List of Object) Fixed Delay BackOff Strategy. (see [below for nested schema](#nestedatt--fixed_delay_backoff_strategy))
 - `full_jitter_backoff_strategy` (List of Object) Full Jitter BackOff Strategy. (see [below for nested schema](#nestedatt--full_jitter_backoff_strategy))
 - `id` (String) The ID of this resource.
@@ -43,7 +44,6 @@ data "harness_platform_connector_aws" "example" {
 - `irsa` (List of Object) Use IAM role for service accounts. (see [below for nested schema](#nestedatt--irsa))
 - `manual` (List of Object) Use IAM role for service accounts. (see [below for nested schema](#nestedatt--manual))
 - `oidc_authentication` (List of Object) Authentication using harness oidc. (see [below for nested schema](#nestedatt--oidc_authentication))
-- `region` AWS Region to perform Connection test of Connector.
 - `tags` (Set of String) Tags to associate with the resource.
 
 <a id="nestedatt--cross_account_access"></a>
@@ -51,8 +51,8 @@ data "harness_platform_connector_aws" "example" {
 
 Read-Only:
 
-- `external_id` (String) If the administrator of the account to which the role belongs provided you with an external ID, then enter that value.
-- `role_arn` (String) The Amazon Resource Name (ARN) of the role that you want to assume. This is an IAM role in the target AWS account.
+- `external_id` (String)
+- `role_arn` (String)
 
 
 <a id="nestedatt--equal_jitter_backoff_strategy"></a>
@@ -60,9 +60,9 @@ Read-Only:
 
 Read-Only:
 
-- `base_delay` (Number) Base delay.
-- `max_backoff_time` (Number) Max BackOff Time.
-- `retry_count` (Number) Retry Count.
+- `base_delay` (Number)
+- `max_backoff_time` (Number)
+- `retry_count` (Number)
 
 
 <a id="nestedatt--fixed_delay_backoff_strategy"></a>
@@ -70,8 +70,8 @@ Read-Only:
 
 Read-Only:
 
-- `fixed_backoff` (Number) Fixed Backoff.
-- `retry_count` (Number) Retry Count.
+- `fixed_backoff` (Number)
+- `retry_count` (Number)
 
 
 <a id="nestedatt--full_jitter_backoff_strategy"></a>
@@ -79,9 +79,9 @@ Read-Only:
 
 Read-Only:
 
-- `base_delay` (Number) Base delay.
-- `max_backoff_time` (Number) Max BackOff Time.
-- `retry_count` (Number) Retry Count.
+- `base_delay` (Number)
+- `max_backoff_time` (Number)
+- `retry_count` (Number)
 
 
 <a id="nestedatt--inherit_from_delegate"></a>
@@ -89,8 +89,8 @@ Read-Only:
 
 Read-Only:
 
-- `delegate_selectors` (Set of String) The delegates to inherit the credentials from.
-- `region` AWS Region to perform Connection test of Connector.
+- `delegate_selectors` (Set of String)
+- `region` (String)
 
 
 <a id="nestedatt--irsa"></a>
@@ -98,8 +98,8 @@ Read-Only:
 
 Read-Only:
 
-- `delegate_selectors` (Set of String) The delegates to inherit the credentials from.
-- `region` AWS Region to perform Connection test of Connector.
+- `delegate_selectors` (Set of String)
+- `region` (String)
 
 
 <a id="nestedatt--manual"></a>
@@ -107,20 +107,20 @@ Read-Only:
 
 Read-Only:
 
-- `access_key` (String) AWS access key.
-- `access_key_ref` (String) Reference to the Harness secret containing the aws access key. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
-- `delegate_selectors` (Set of String) Connect only use delegates with these tags.
-- `secret_key_ref` (String) Reference to the Harness secret containing the aws secret key. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
-- `session_token_ref` (String) Reference to the Harness secret containing the aws session token.
-- `region` AWS Region to perform Connection test of Connector.
+- `access_key` (String)
+- `access_key_plain_text` (String)
+- `access_key_ref` (String)
+- `delegate_selectors` (Set of String)
+- `region` (String)
+- `secret_key_ref` (String)
+- `session_token_ref` (String)
 
 
 <a id="nestedatt--oidc_authentication"></a>
-### Nested Schema for `oidc authentication`
+### Nested Schema for `oidc_authentication`
 
 Read-Only:
 
-- `iam_role_arn` (String) The IAM Role to assume the credentials from.
-- `delegate_selectors` (Set of String) The delegates to inherit the credentials from.
-- `region` AWS Region to perform Connection test of Connector.
-
+- `delegate_selectors` (Set of String)
+- `iam_role_arn` (String)
+- `region` (String)

--- a/internal/service/cd_nextgen/connector/cloudProviders/aws.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/aws.go
@@ -58,11 +58,11 @@ func ResourceConnectorAws() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 						},
-                        "session_token_ref": {
-                            Description: "Reference to the Harness secret containing the aws session token." + secret_ref_text,
-                            Type:        schema.TypeString,
-                            Optional:    true,
-                        },
+						"session_token_ref": {
+							Description: "Reference to the Harness secret containing the aws session token." + secret_ref_text,
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"delegate_selectors": {
 							Description: "Connect only use delegates with these tags.",
 							Type:        schema.TypeSet,
@@ -286,6 +286,11 @@ func ResourceConnectorAws() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"execute_on_delegate": {
+				Description: "Enable this flag to execute on Delegate",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 		},
 	}
 
@@ -351,9 +356,9 @@ func buildConnectorAws(d *schema.ResourceData) *nextgen.ConnectorInfo {
 			connector.Aws.Credential.ManualConfig.SecretKeyRef = attr
 		}
 
-        if attr := config["session_token_ref"].(string); attr != "" {
-            connector.Aws.Credential.ManualConfig.SessionTokenRef = attr
-        }
+		if attr := config["session_token_ref"].(string); attr != "" {
+			connector.Aws.Credential.ManualConfig.SessionTokenRef = attr
+		}
 
 		if attr := config["delegate_selectors"].(*schema.Set).List(); len(attr) > 0 {
 			connector.Aws.DelegateSelectors = utils.InterfaceSliceToStringSlice(attr)
@@ -468,6 +473,9 @@ func buildConnectorAws(d *schema.ResourceData) *nextgen.ConnectorInfo {
 			connector.Aws.AwsSdkClientBackOffStrategyOverride.FixedDelay.FixedBackoff = int64(val.(int))
 		}
 	}
+	if attr, ok := d.GetOk("execute_on_delegate"); ok {
+		connector.Aws.ExecuteOnDelegate = attr.(bool)
+	}
 
 	return connector
 }
@@ -546,6 +554,7 @@ func readConnectorAws(d *schema.ResourceData, connector *nextgen.ConnectorInfo) 
 		default:
 			return fmt.Errorf("unsupported aws credential type: %s", connector.Aws.AwsSdkClientBackOffStrategyOverride.Type_)
 		}
+		d.Set("execute_on_delegate", connector.Aws.ExecuteOnDelegate)
 
 	}
 	return nil

--- a/internal/service/cd_nextgen/connector/cloudProviders/aws_data_source.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/aws_data_source.go
@@ -37,11 +37,11 @@ func DatasourceConnectorAws() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
-                        "session_token_ref": {
-                            Description: "Reference to the Harness secret containing the aws session token." + secret_ref_text,
-                            Type:        schema.TypeString,
-                            Optional:    true,
-                        },
+						"session_token_ref": {
+							Description: "Reference to the Harness secret containing the aws session token." + secret_ref_text,
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"delegate_selectors": {
 							Description: "Connect only use delegates with these tags.",
 							Type:        schema.TypeSet,
@@ -206,6 +206,11 @@ func DatasourceConnectorAws() *schema.Resource {
 						},
 					},
 				},
+			},
+			"execute_on_delegate": {
+				Description: "Execute on delegate or not.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/service/cd_nextgen/connector/cloudProviders/azure_cloud_provider.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/azure_cloud_provider.go
@@ -313,6 +313,9 @@ func buildConnectorAzureCloudProvider(d *schema.ResourceData) *nextgen.Connector
 	if attr, ok := d.GetOk("azure_environment_type"); ok {
 		connector.Azure.AzureEnvironmentType = attr.(string)
 	}
+	if attr, ok := d.GetOk("execute_on_delegate"); ok {
+		connector.Azure.ExecuteOnDelegate = attr.(bool)
+	}
 
 	return connector
 }
@@ -327,6 +330,7 @@ func readConnectorAzureCloudProvider(d *schema.ResourceData, connector *nextgen.
 	})
 	d.Set("delegate_selectors", connector.Azure.DelegateSelectors)
 	d.Set("azure_environment_type", connector.Azure.AzureEnvironmentType)
+	d.Set("execute_on_delegate", connector.Azure.ExecuteOnDelegate)
 
 	return nil
 }


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change
added execute_on_delagte param support for AWS and AZURE CP Connectors

**Summary:**
we need this support to make sure that our tf providers is working correctly.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
