### PR TITLE
fix: [CDS-105804]: Add forceDelete for GitOps cluster resource

### DIFF
--- a/docs/resources/platform_gitops_cluster.md
+++ b/docs/resources/platform_gitops_cluster.md
@@ -118,6 +118,7 @@ resource "harness_platform_gitops_cluster" "example" {
 - `account_id` (String, Deprecated) Account identifier of the GitOps cluster.
 - `org_id` (String) Organization identifier of the cluster.
 - `project_id` (String) Project identifier of the GitOps cluster.
+- `force_delete` (Boolean) Indicates if the cluster should be deleted forcefully, regardless of existing applications using that repo.
 - `request` (Block List, Max: 1) Cluster create or update request. (see [below for nested schema](#nestedblock--request))
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,6 @@ require (
 	gotest.tools/v3 v3.3.0 // indirect
 )
 
-//replace github.com/harness/harness-go-sdk => ../harness-go-sdk
+// replace github.com/harness/harness-go-sdk => ../harness-go-sdk
 
 // replace github.com/harness/harness-openapi-go-client => ../harness-openapi-go-client

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.46.4
 	github.com/docker/docker v24.0.5+incompatible
-	github.com/harness/harness-go-sdk v0.4.28
+	github.com/harness/harness-go-sdk v0.4.30
 	github.com/harness/harness-openapi-go-client v0.0.21
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -85,6 +85,6 @@ require (
 	gotest.tools/v3 v3.3.0 // indirect
 )
 
-// replace github.com/harness/harness-go-sdk => ../harness-go-sdk
+//replace github.com/harness/harness-go-sdk => ../harness-go-sdk
 
 // replace github.com/harness/harness-openapi-go-client => ../harness-openapi-go-client

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/harness/harness-go-sdk v0.4.28 h1:Vlya0Q1odN3fb4FGMc9mOUcEK96i9tha0x9If4giCv8=
-github.com/harness/harness-go-sdk v0.4.28/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
+github.com/harness/harness-go-sdk v0.4.30 h1:/CEq337KYapoX9+OZzD+SM6PQ/+wftSOIML3SNqnF38=
+github.com/harness/harness-go-sdk v0.4.30/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
 github.com/harness/harness-openapi-go-client v0.0.21 h1:VtJnpQKZvCAlaCmUPbNR69OT3c5WRdhNN5TOgUwtwZ4=
 github.com/harness/harness-openapi-go-client v0.0.21/go.mod h1:u0vqYb994BJGotmEwJevF4L3BNAdU9i8ui2d22gmLPA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -503,6 +503,7 @@ func resourceGitopsClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		OrgIdentifier:     optional.NewString(d.Get("org_id").(string)),
 		ProjectIdentifier: optional.NewString(d.Get("project_id").(string)),
 		ForceDelete:       optional.NewBool(d.Get("force_delete").(bool)),
+		QueryServer:       optional.NewString(d.Get("request.0.cluster.0.server").(string)),
 	})
 
 	if err != nil {

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -56,6 +56,11 @@ func ResourceGitopsCluster() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"force_delete": {
+				Description: "Indicates if the cluster should be deleted forcefully, regardless of existing applications using that repo.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"request": {
 				Description: "Cluster create or update request.",
 				Type:        schema.TypeList,
@@ -497,6 +502,7 @@ func resourceGitopsClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		AccountIdentifier: optional.NewString(c.AccountId),
 		OrgIdentifier:     optional.NewString(d.Get("org_id").(string)),
 		ProjectIdentifier: optional.NewString(d.Get("project_id").(string)),
+		ForceDelete:       optional.NewBool(d.Get("force_delete").(bool)),
 	})
 
 	if err != nil {

--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -57,7 +57,7 @@ func ResourceGitopsCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"force_delete": {
-				Description: "Indicates if the cluster should be deleted forcefully, regardless of existing applications using that repo.",
+				Description: "Indicates if the cluster should be deleted forcefully, regardless of existing applications using that cluster.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change

**Summary:**
Provide a brief overview of what the PR does and why it is needed.

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
