### PR TITLE
[feat]: [DBOPS-845]: JDBC connector ServiceAccount auth

### DIFF
--- a/.changelog/1160.txt
+++ b/.changelog/1160.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+harness_platform_connector_jdbc: adding new ServiceAccount auth support
+```

--- a/docs/data-sources/platform_connector_jdbc.md
+++ b/docs/data-sources/platform_connector_jdbc.md
@@ -45,6 +45,26 @@ data "harness_platform_connector_jdbc" "example" {
 
 Read-Only:
 
+- `auth_type` (String)
+- `password_ref` (String)
+- `service_account` (List of Object) (see [below for nested schema](#nestedobjatt--credentials--service_account))
+- `username` (String)
+- `username_password` (List of Object) (see [below for nested schema](#nestedobjatt--credentials--username_password))
+- `username_ref` (String)
+
+<a id="nestedobjatt--credentials--service_account"></a>
+### Nested Schema for `credentials.service_account`
+
+Read-Only:
+
+- `token_ref` (String)
+
+
+<a id="nestedobjatt--credentials--username_password"></a>
+### Nested Schema for `credentials.username_password`
+
+Read-Only:
+
 - `password_ref` (String)
 - `username` (String)
 - `username_ref` (String)

--- a/docs/resources/platform_connector_jdbc.md
+++ b/docs/resources/platform_connector_jdbc.md
@@ -21,7 +21,69 @@ resource "harness_platform_connector_jdbc" "test" {
   url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
   delegate_selectors = ["harness-delegate"]
   credentials {
+    auth_type = "ServiceAccount"
+    service_account {
+      token_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
+    username_password {
+      username     = "admin"
+      password_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
+    username_password {
+      username_ref = "account.user_ref"
+      password_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type    = "UsernamePassword"
     username     = "admin"
+    password_ref = "account.secret_id"
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type    = "UsernamePassword"
+    username_ref = "account.user_ref"
     password_ref = "account.secret_id"
   }
 }
@@ -52,14 +114,34 @@ resource "harness_platform_connector_jdbc" "test" {
 <a id="nestedblock--credentials"></a>
 ### Nested Schema for `credentials`
 
+Optional:
+
+- `auth_type` (String) Authentication types for JDBC connector
+- `password_ref` (String) The reference to the Harness secret containing the password to use for the database server. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+- `service_account` (Block List, Max: 1) Authenticate using service account. (see [below for nested schema](#nestedblock--credentials--service_account))
+- `username` (String) The username to use for the database server.
+- `username_password` (Block List, Max: 1) Authenticate using username password. (see [below for nested schema](#nestedblock--credentials--username_password))
+- `username_ref` (String) The reference to the Harness secret containing the username to use for the database server. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+
+<a id="nestedblock--credentials--service_account"></a>
+### Nested Schema for `credentials.service_account`
+
 Required:
 
-- `password_ref` (String) The reference to the Harness secret containing the password to use for the database server. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+- `token_ref` (String) Reference to a secret containing the token to use for authentication. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+
+
+<a id="nestedblock--credentials--username_password"></a>
+### Nested Schema for `credentials.username_password`
+
+Required:
+
+- `password_ref` (String) Reference to a secret containing the password to use for authentication. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
 
 Optional:
 
-- `username` (String) The username to use for the database server.
-- `username_ref` (String) The reference to the Harness secret containing the username to use for the database server. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
+- `username` (String) Username to use for authentication.
+- `username_ref` (String) Reference to a secret containing the username to use for authentication. To reference a secret at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a secret at the account scope, prefix 'account` to the expression: account.{identifier}.
 
 ## Import
 

--- a/examples/resources/harness_platform_connector_jdbc/resource.tf
+++ b/examples/resources/harness_platform_connector_jdbc/resource.tf
@@ -6,7 +6,69 @@ resource "harness_platform_connector_jdbc" "test" {
   url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
   delegate_selectors = ["harness-delegate"]
   credentials {
+    auth_type = "ServiceAccount"
+    service_account {
+      token_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
+    username_password {
+      username     = "admin"
+      password_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
+    username_password {
+      username_ref     = "account.user_ref"
+      password_ref = "account.secret_id"
+    }
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
     username     = "admin"
+    password_ref = "account.secret_id"
+  }
+}
+
+resource "harness_platform_connector_jdbc" "test" {
+  identifier         = "identifer"
+  name               = "name"
+  description        = "test"
+  tags               = ["foo:bar"]
+  url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+  delegate_selectors = ["harness-delegate"]
+  credentials {
+    auth_type = "UsernamePassword"
+    username_ref     = "account.user_ref"
     password_ref = "account.secret_id"
   }
 }

--- a/examples/resources/harness_platform_connector_jdbc/resource.tf
+++ b/examples/resources/harness_platform_connector_jdbc/resource.tf
@@ -39,7 +39,7 @@ resource "harness_platform_connector_jdbc" "test" {
   credentials {
     auth_type = "UsernamePassword"
     username_password {
-      username_ref     = "account.user_ref"
+      username_ref = "account.user_ref"
       password_ref = "account.secret_id"
     }
   }
@@ -53,7 +53,7 @@ resource "harness_platform_connector_jdbc" "test" {
   url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
   delegate_selectors = ["harness-delegate"]
   credentials {
-    auth_type = "UsernamePassword"
+    auth_type    = "UsernamePassword"
     username     = "admin"
     password_ref = "account.secret_id"
   }
@@ -67,8 +67,8 @@ resource "harness_platform_connector_jdbc" "test" {
   url                = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
   delegate_selectors = ["harness-delegate"]
   credentials {
-    auth_type = "UsernamePassword"
-    username_ref     = "account.user_ref"
+    auth_type    = "UsernamePassword"
+    username_ref = "account.user_ref"
     password_ref = "account.secret_id"
   }
 }

--- a/internal/service/platform/connector/jdbc.go
+++ b/internal/service/platform/connector/jdbc.go
@@ -2,12 +2,14 @@ package connector
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/harness/harness-go-sdk/harness/nextgen"
 	"github.com/harness/terraform-provider-harness/helpers"
 	"github.com/harness/terraform-provider-harness/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceConnectorJDBC() *schema.Resource {
@@ -38,30 +40,109 @@ func ResourceConnectorJDBC() *schema.Resource {
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"auth_type": {
+							Description:  "Authentication types for JDBC connector",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      nextgen.JDBCAuthTypes.UsernamePassword.String(),
+							ValidateFunc: validation.StringInSlice([]string{nextgen.JDBCAuthTypes.UsernamePassword.String(), nextgen.JDBCAuthTypes.ServiceAccount.String()}, false),
+						},
 						"username": {
 							Description:   "The username to use for the database server.",
 							Type:          schema.TypeString,
 							Optional:      true,
-							ConflictsWith: []string{"credentials.0.username_ref"},
+							ConflictsWith: []string{"credentials.0.username_ref", "credentials.0.username_password", "credentials.0.service_account"},
 							AtLeastOneOf: []string{
 								"credentials.0.username",
 								"credentials.0.username_ref",
+								"credentials.0.username_password",
+								"credentials.0.service_account",
 							},
 						},
 						"username_ref": {
 							Description:   "The reference to the Harness secret containing the username to use for the database server." + secret_ref_text,
 							Type:          schema.TypeString,
 							Optional:      true,
-							ConflictsWith: []string{"credentials.0.username"},
+							ConflictsWith: []string{"credentials.0.username", "credentials.0.username_password", "credentials.0.service_account"},
 							AtLeastOneOf: []string{
 								"credentials.0.username",
 								"credentials.0.username_ref",
+								"credentials.0.username_password",
+								"credentials.0.service_account",
 							},
 						},
 						"password_ref": {
-							Description: "The reference to the Harness secret containing the password to use for the database server." + secret_ref_text,
-							Type:        schema.TypeString,
-							Required:    true,
+							Description:   "The reference to the Harness secret containing the password to use for the database server." + secret_ref_text,
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"credentials.0.username_password", "credentials.0.service_account"},
+							AtLeastOneOf: []string{
+								"credentials.0.password_ref",
+								"credentials.0.username_password",
+								"credentials.0.service_account",
+							},
+						},
+						"username_password": {
+							Description:   "Authenticate using username password.",
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							ConflictsWith: []string{"credentials.0.username", "credentials.0.username_ref", "credentials.0.password_ref", "credentials.0.service_account"},
+							AtLeastOneOf: []string{
+								"credentials.0.username_password",
+								"credentials.0.service_account",
+								"credentials.0.password_ref",
+							},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Description:   "Username to use for authentication.",
+										Type:          schema.TypeString,
+										Optional:      true,
+										ConflictsWith: []string{"credentials.0.username_password.0.username_ref"},
+										AtLeastOneOf: []string{
+											"credentials.0.username_password.0.username",
+											"credentials.0.username_password.0.username_ref",
+										},
+									},
+									"username_ref": {
+										Description:   "Reference to a secret containing the username to use for authentication." + secret_ref_text,
+										Type:          schema.TypeString,
+										Optional:      true,
+										ConflictsWith: []string{"credentials.0.username_password.0.username"},
+										AtLeastOneOf: []string{
+											"credentials.0.username_password.0.username",
+											"credentials.0.username_password.0.username_ref",
+										},
+									},
+									"password_ref": {
+										Description: "Reference to a secret containing the password to use for authentication." + secret_ref_text,
+										Type:        schema.TypeString,
+										Required:    true,
+									},
+								},
+							},
+						},
+						"service_account": {
+							Description:   "Authenticate using service account.",
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							ConflictsWith: []string{"credentials.0.username", "credentials.0.username_ref", "credentials.0.password_ref", "credentials.0.username_password"},
+							AtLeastOneOf: []string{
+								"credentials.0.username_password",
+								"credentials.0.service_account",
+								"credentials.0.password_ref",
+							},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"token_ref": {
+										Description: "Reference to a secret containing the token to use for authentication." + secret_ref_text,
+										Type:        schema.TypeString,
+										Required:    true,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -107,51 +188,126 @@ func resourceConnectorJDBCCreateOrUpdate(ctx context.Context, d *schema.Resource
 }
 
 func buildConnectorJDBC(d *schema.ResourceData) *nextgen.ConnectorInfo {
-	connector := &nextgen.ConnectorInfo{
+	config := d.Get("credentials").([]interface{})[0].(map[string]interface{})
+	authType := config["auth_type"].(string)
+
+	connector1 := &nextgen.ConnectorInfo{
 		Type_: nextgen.ConnectorTypes.JDBC,
 		JDBC: &nextgen.JdbcConnector{
 			Url: d.Get("url").(string),
-			Auth: &nextgen.JdbcAuthenticationDto{
-				Type_:            nextgen.JDBCAuthTypes.UsernamePassword,
-				UsernamePassword: &nextgen.JdbcUserNamePasswordDto{},
-			},
 			// As currently we support through delegate only
-			ExecuteOnDelegate: true,
+			ExecuteOnDelegate:    true,
+			IgnoreTestConnection: false,
 		},
 	}
 
-	config := d.Get("credentials").([]interface{})[0].(map[string]interface{})
+	switch authType {
+	case nextgen.JDBCAuthTypes.UsernamePassword.String():
+		{
+			connector1.JDBC.Auth = &nextgen.JdbcAuthenticationDto{
+				Type_:            nextgen.JDBCAuthTypes.UsernamePassword,
+				UsernamePassword: &nextgen.JdbcUserNamePasswordDto{},
+			}
+			if usernamePasswordConfig, ok := config["username_password"]; ok && len(usernamePasswordConfig.([]interface{})) > 0 {
+				config = usernamePasswordConfig.([]interface{})[0].(map[string]interface{})
+				if attr, ok := config["username"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.Username = attr.(string)
+				}
+				if attr, ok := config["username_ref"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.UsernameRef = attr.(string)
+				}
+				if attr, ok := config["password_ref"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.PasswordRef = attr.(string)
+				}
+			} else {
+				if attr, ok := config["username"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.Username = attr.(string)
+				}
 
-	if attr, ok := config["username"]; ok {
-		connector.JDBC.Auth.UsernamePassword.Username = attr.(string)
-	}
+				if attr, ok := config["username_ref"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.UsernameRef = attr.(string)
+				}
 
-	if attr, ok := config["username_ref"]; ok {
-		connector.JDBC.Auth.UsernamePassword.UsernameRef = attr.(string)
-	}
-
-	if attr, ok := config["password_ref"]; ok {
-		connector.JDBC.Auth.UsernamePassword.PasswordRef = attr.(string)
+				if attr, ok := config["password_ref"]; ok {
+					connector1.JDBC.Auth.UsernamePassword.PasswordRef = attr.(string)
+				}
+			}
+		}
+	case nextgen.JDBCAuthTypes.ServiceAccount.String():
+		{
+			connector1.JDBC.Auth = &nextgen.JdbcAuthenticationDto{
+				Type_:          nextgen.JDBCAuthTypes.ServiceAccount,
+				ServiceAccount: &nextgen.JdbcServiceAccountDto{},
+			}
+			if serviceAccountConfig, ok := config["service_account"]; ok && len(serviceAccountConfig.([]interface{})) > 0 {
+				config = serviceAccountConfig.([]interface{})[0].(map[string]interface{})
+				if attr, ok := config["token_ref"]; ok {
+					connector1.JDBC.Auth.ServiceAccount.ServiceAccountTokenRef = attr.(string)
+				}
+			}
+		}
+	default:
+		panic(fmt.Sprintf("unknown jdbc auth method type %s", authType))
 	}
 
 	if attr, ok := d.GetOk("delegate_selectors"); ok {
-		connector.JDBC.DelegateSelectors = utils.InterfaceSliceToStringSlice(attr.(*schema.Set).List())
+		connector1.JDBC.DelegateSelectors = utils.InterfaceSliceToStringSlice(attr.(*schema.Set).List())
 	}
 
-	return connector
+	return connector1
 }
 
 func readConnectorJDBC(d *schema.ResourceData, connector *nextgen.ConnectorInfo) error {
 	d.Set("url", connector.JDBC.Url)
 	d.Set("delegate_selectors", connector.JDBC.DelegateSelectors)
-
-	d.Set("credentials", []map[string]interface{}{
-		{
-			"username":     connector.JDBC.Auth.UsernamePassword.Username,
-			"username_ref": connector.JDBC.Auth.UsernamePassword.UsernameRef,
-			"password_ref": connector.JDBC.Auth.UsernamePassword.PasswordRef,
-		},
-	})
+	switch connector.JDBC.Auth.Type_ {
+	case nextgen.JDBCAuthTypes.UsernamePassword:
+		useFirstClassUserAndPasswordVars := false
+		_, ok := d.GetOk("credentials")
+		if ok {
+			cred := d.Get("credentials").([]interface{})[0].(map[string]interface{})
+			passwordRefValue, passwordRefKeyPresent := cred["password_ref"]
+			if passwordRefKeyPresent && passwordRefValue != "" {
+				useFirstClassUserAndPasswordVars = true
+			}
+		}
+		if useFirstClassUserAndPasswordVars {
+			d.Set("credentials", []map[string]interface{}{
+				{
+					"auth_type":    nextgen.JDBCAuthTypes.UsernamePassword.String(),
+					"username":     connector.JDBC.Auth.UsernamePassword.Username,
+					"username_ref": connector.JDBC.Auth.UsernamePassword.UsernameRef,
+					"password_ref": connector.JDBC.Auth.UsernamePassword.PasswordRef,
+				},
+			})
+		} else {
+			d.Set("credentials", []map[string]interface{}{
+				{
+					"auth_type": nextgen.JDBCAuthTypes.UsernamePassword.String(),
+					"username_password": []map[string]interface{}{
+						{
+							"username":     connector.JDBC.Auth.UsernamePassword.Username,
+							"username_ref": connector.JDBC.Auth.UsernamePassword.UsernameRef,
+							"password_ref": connector.JDBC.Auth.UsernamePassword.PasswordRef,
+						},
+					},
+				},
+			})
+		}
+	case nextgen.JDBCAuthTypes.ServiceAccount:
+		d.Set("credentials", []map[string]interface{}{
+			{
+				"auth_type": nextgen.JDBCAuthTypes.ServiceAccount.String(),
+				"service_account": []map[string]interface{}{
+					{
+						"token_ref": connector.JDBC.Auth.ServiceAccount.ServiceAccountTokenRef,
+					},
+				},
+			},
+		})
+	default:
+		return fmt.Errorf("unknown jdbc auth method type %s", connector.JDBC.Auth.Type_)
+	}
 
 	return nil
 }

--- a/internal/service/platform/connector/jdbc_data_source.go
+++ b/internal/service/platform/connector/jdbc_data_source.go
@@ -28,6 +28,11 @@ func DatasourceConnectorJDBC() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"auth_type": {
+							Description: "Authentication types for JDBC connector",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
 						"username": {
 							Description: "The username to use for the database server.",
 							Type:        schema.TypeString,
@@ -42,6 +47,44 @@ func DatasourceConnectorJDBC() *schema.Resource {
 							Description: "The reference to the Harness secret containing the password to use for the database server." + secret_ref_text,
 							Type:        schema.TypeString,
 							Computed:    true,
+						},
+						"username_password": {
+							Description: "Authenticate using username password.",
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Description: "Username to use for authentication.",
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"username_ref": {
+										Description: "Reference to a secret containing the username to use for authentication." + secret_ref_text,
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+									"password_ref": {
+										Description: "Reference to a secret containing the password to use for authentication." + secret_ref_text,
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+								},
+							},
+						},
+						"service_account": {
+							Description: "Authenticate using service account.",
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"token_ref": {
+										Description: "Reference to a secret containing the token to use for authentication." + secret_ref_text,
+										Type:        schema.TypeString,
+										Computed:    true,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/internal/service/platform/connector/jdbc_data_source_test.go
+++ b/internal/service/platform/connector/jdbc_data_source_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAccDataSourceConnectorJDBC(t *testing.T) {
-
 	var (
 		name         = fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(4))
 		resourceName = "data.harness_platform_connector_jdbc.test"
@@ -33,7 +32,72 @@ func TestAccDataSourceConnectorJDBC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
 					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "credentials.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceConnectorJDBCDefaultAuth(t *testing.T) {
+	var (
+		name         = fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(4))
+		resourceName = "data.harness_platform_connector_jdbc.test"
+	)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConnectorJDBCDefaultAuth(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", name),
+					resource.TestCheckResourceAttr(resourceName, "identifier", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceConnectorJDBCServiceAccountAuth(t *testing.T) {
+	var (
+		name         = fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(4))
+		resourceName = "data.harness_platform_connector_jdbc.test"
+	)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConnectorJDBCServiceAccountAuth(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", name),
+					resource.TestCheckResourceAttr(resourceName, "identifier", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.service_account.0.token_ref", fmt.Sprintf("account.%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "ServiceAccount"),
 				),
 			},
 		},
@@ -53,27 +117,95 @@ func testAccDataSourceConnectorJDBC(name string) string {
 		value = "secret"
 	}
 
-		resource "harness_platform_connector_jdbc" "test" {
-			identifier = "%[1]s"
-			name = "%[1]s"
-			description = "test"
-			tags = ["foo:bar"]
-			url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
-			delegate_selectors = ["harness-delegate"]
-			credentials {
+	resource "harness_platform_connector_jdbc" "test" {
+		identifier = "%[1]s"
+		name = "%[1]s"
+		description = "test"
+		tags = ["foo:bar"]
+		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+		delegate_selectors = ["harness-delegate"]
+		credentials {
+			auth_type = "UsernamePassword"
+			username_password {
 				username = "admin"
 				password_ref = "account.${harness_platform_secret_text.test.id}"
 			}
-			depends_on = [time_sleep.wait_4_seconds]
 		}
+		depends_on = [harness_platform_secret_text.test]
+	}
 
-		resource "time_sleep" "wait_4_seconds" {
-			depends_on = [harness_platform_secret_text.test]
-			destroy_duration = "4s"
-		}
+	data "harness_platform_connector_jdbc" "test" {
+		identifier = harness_platform_connector_jdbc.test.identifier
+	}
+	`, name)
+}
 
-		data "harness_platform_connector_jdbc" "test" {
-			identifier = harness_platform_connector_jdbc.test.identifier
+func testAccDataSourceConnectorJDBCDefaultAuth(name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[1]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+	}
+
+	resource "harness_platform_connector_jdbc" "test" {
+		identifier = "%[1]s"
+		name = "%[1]s"
+		description = "test"
+		tags = ["foo:bar"]
+		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+		delegate_selectors = ["harness-delegate"]
+		credentials {
+			username_password {
+				username = "admin"
+				password_ref = "account.${harness_platform_secret_text.test.id}"
+			}
 		}
+		depends_on = [harness_platform_secret_text.test]
+	}
+
+	data "harness_platform_connector_jdbc" "test" {
+		identifier = harness_platform_connector_jdbc.test.identifier
+	}
+	`, name)
+}
+
+func testAccDataSourceConnectorJDBCServiceAccountAuth(name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[1]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+	}
+
+	resource "harness_platform_connector_jdbc" "test" {
+		identifier = "%[1]s"
+		name = "%[1]s"
+		description = "test"
+		tags = ["foo:bar"]
+		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+		delegate_selectors = ["harness-delegate"]
+		credentials {
+			auth_type = "ServiceAccount"
+			service_account {
+				token_ref = "account.${harness_platform_secret_text.test.id}"
+			}
+		}
+		depends_on = [harness_platform_secret_text.test]
+	}
+
+	data "harness_platform_connector_jdbc" "test" {
+		identifier = harness_platform_connector_jdbc.test.identifier
+	}
 	`, name)
 }

--- a/internal/service/platform/connector/jdbc_test.go
+++ b/internal/service/platform/connector/jdbc_test.go
@@ -34,7 +34,9 @@ func TestAccResourceConnectorJDBC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
 					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "credentials.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
 				),
 			},
 			{
@@ -47,7 +49,115 @@ func TestAccResourceConnectorJDBC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
 					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "credentials.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceConnectorJDBCDefaultAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_jdbc.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnectorJDBCDefaultAuth(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
+				),
+			},
+			{
+				Config: testAccResourceConnectorJDBCDefaultAuth(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.username", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.username_password.0.password_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "UsernamePassword"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceConnectorJDBCServiceAccountAuth(t *testing.T) {
+
+	id := fmt.Sprintf("%s_%s", t.Name(), utils.RandStringBytes(5))
+	name := id
+	updatedName := fmt.Sprintf("%s_updated", name)
+	resourceName := "harness_platform_connector_jdbc.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccConnectorDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConnectorJDBCServiceAccountAuth(id, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.service_account.0.token_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "ServiceAccount"),
+				),
+			},
+			{
+				Config: testAccResourceConnectorJDBCServiceAccountAuth(id, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "identifier", id),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "url", "jdbc:sqlserver://1.2.3;trustServerCertificate=true"),
+					resource.TestCheckResourceAttr(resourceName, "delegate_selectors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.service_account.0.token_ref", fmt.Sprintf("account.%s", id)),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.auth_type", "ServiceAccount"),
 				),
 			},
 			{
@@ -81,15 +191,77 @@ func testAccResourceConnectorJDBC(id string, name string) string {
 		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
 		delegate_selectors = ["harness-delegate"]
 		credentials {
-			username = "admin"
-			password_ref = "account.${harness_platform_secret_text.test.id}"
+			auth_type = "UsernamePassword"
+			username_password {
+				username = "admin"
+				password_ref = "account.${harness_platform_secret_text.test.id}"
+			}
 		}
-		depends_on = [time_sleep.wait_4_seconds]
+		depends_on = [harness_platform_secret_text.test]
+	}
+`, id, name)
+}
+
+func testAccResourceConnectorJDBCDefaultAuth(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
 	}
 
-	resource "time_sleep" "wait_4_seconds" {
+	resource "harness_platform_connector_jdbc" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+		delegate_selectors = ["harness-delegate"]
+		credentials {
+			username_password {
+				username = "admin"
+				password_ref = "account.${harness_platform_secret_text.test.id}"
+			}
+		}
 		depends_on = [harness_platform_secret_text.test]
-		destroy_duration = "4s"
+	}
+`, id, name)
+}
+
+func testAccResourceConnectorJDBCServiceAccountAuth(id string, name string) string {
+	return fmt.Sprintf(`
+	resource "harness_platform_secret_text" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		secret_manager_identifier = "harnessSecretManager"
+		value_type = "Inline"
+		value = "secret"
+	}
+
+	resource "harness_platform_connector_jdbc" "test" {
+		identifier = "%[1]s"
+		name = "%[2]s"
+		description = "test"
+		tags = ["foo:bar"]
+
+		url = "jdbc:sqlserver://1.2.3;trustServerCertificate=true"
+		delegate_selectors = ["harness-delegate"]
+		credentials {
+			auth_type = "ServiceAccount"
+			service_account {
+				token_ref = "account.${harness_platform_secret_text.test.id}"
+			}
+		}
+		depends_on = [harness_platform_secret_text.test]
 	}
 `, id, name)
 }


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change
**Summary:**
This PR handles the new auth type `ServiceAccount` for JDBC connector.
**Details:**
Earlier only UsernamePassword auth type was supported.
**Related Issues:**
https://harness.atlassian.net/browse/DBOPS-845
**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [x] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
