### PR TITLE
fix:[CDS-106621]: Set execute on delete to true only on create

### DIFF
--- a/internal/service/cd_nextgen/connector/cloudProviders/aws.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/aws.go
@@ -388,7 +388,9 @@ func buildConnectorAws(d *schema.ResourceData) *nextgen.ConnectorInfo {
 		}
 
 		// Set the execute_on_delegate attribute to true when creating a connector that use IRSA
-		connector.Aws.ExecuteOnDelegate = true
+		if d.Id() == "" {
+			connector.Aws.ExecuteOnDelegate = true
+		}
 	}
 
 	if attr, ok := d.GetOk("inherit_from_delegate"); ok {
@@ -405,7 +407,9 @@ func buildConnectorAws(d *schema.ResourceData) *nextgen.ConnectorInfo {
 
 		// Set the execute_on_delegate attribute to true when creating a connector that uses
 		// credentials inherited from the delegate.
-		connector.Aws.ExecuteOnDelegate = true
+		if d.Id() == "" {
+			connector.Aws.ExecuteOnDelegate = true
+		}
 	}
 
 	if attr, ok := d.GetOk("oidc_authentication"); ok {


### PR DESCRIPTION
**Title:**
Set execute on delete to true only on create

**Summary:**
This PR addresses an issue with the AWS connector update process. Specifically, when attempting to update an AWS connector using IRSA or inherit from delegate, the `execute_on_delegate` property was incorrectly being set to true.

The fix ensures that the `execute_on_delegate` value is only set during the connector creation process, and not during the update procedure. This resolves unintended behavior during updates and maintains the correct flow for connector management.

**Details:**
- When trying to update an AWS connector, we are pushing it to have the `execute_on_delegate` set to **true**.
- The fix is related to only setting the value during the connector creation, not during the update procedure.

**Related Issues:**
- CDS-106208
- CDS-105906

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
