### PR TITLE
fix:[CDS-107597] Added missing execute on delegate field to Terraform Cloud Connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.46.4
 	github.com/docker/docker v24.0.5+incompatible
-	github.com/harness/harness-go-sdk v0.4.38
+	github.com/harness/harness-go-sdk v0.4.40
 	github.com/harness/harness-openapi-go-client v0.0.21
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/harness/harness-go-sdk v0.4.38 h1:7tQnZxav57B2YXlxjICAVHxtnlThibLRXotPuRR6Rak=
-github.com/harness/harness-go-sdk v0.4.38/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
+github.com/harness/harness-go-sdk v0.4.40 h1:2f0RhC6z8zl/umQEJz77/yP+gJG/kXpL38zgpTTCfPA=
+github.com/harness/harness-go-sdk v0.4.40/go.mod h1:CPXydorp4zd5Dz2u2FXiHyWL4yd5PQafOMN69cgPSvk=
 github.com/harness/harness-openapi-go-client v0.0.21 h1:VtJnpQKZvCAlaCmUPbNR69OT3c5WRdhNN5TOgUwtwZ4=
 github.com/harness/harness-openapi-go-client v0.0.21/go.mod h1:u0vqYb994BJGotmEwJevF4L3BNAdU9i8ui2d22gmLPA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/service/cd_nextgen/connector/cloudProviders/terraform_cloud.go
+++ b/internal/service/cd_nextgen/connector/cloudProviders/terraform_cloud.go
@@ -56,6 +56,12 @@ func ResourceConnectorTerraformCloud() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"execute_on_delegate": {
+				Description: "Enable this flag to execute on delegate (default: true).",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 
@@ -106,6 +112,24 @@ func buildConnectorTerraformCloud(d *schema.ResourceData) *nextgen.ConnectorInfo
 		},
 	}
 
+	// In the Terraform Plugin SDK (legacy), d.GetOk("attribute") returns false in two cases:
+	//
+	// 	1. When the attribute is not defined by the user.
+	//	2. When the user explicitly sets it to false.
+	//
+	// This happens because false is treated as a zero-value, making GetOk() unable to distinguish between false and 
+	// “not defined”. To handle this, we need to use GetOkExists() instead of GetOk() to check if the attribute is 
+	// defined by the user.
+	v, ok := d.GetOkExists("execute_on_delegate")
+	if !ok {
+		// Set the execute_on_delegate attribute to true when creating the connector; required to keep backward compatibility.
+		if d.Id() == "" {
+			connector.TerraformCloud.ExecuteOnDelegate = true
+		}
+	} else {
+		connector.TerraformCloud.ExecuteOnDelegate = v.(bool)
+	}
+
 	if attr, ok := d.GetOk("url"); ok {
 		connector.TerraformCloud.TerraformCloudUrl = attr.(string)
 	}
@@ -135,6 +159,7 @@ func buildConnectorTerraformCloud(d *schema.ResourceData) *nextgen.ConnectorInfo
 func readConnectorTerraformCloud(d *schema.ResourceData, connector *nextgen.ConnectorInfo) error {
 	d.Set("url", connector.TerraformCloud.TerraformCloudUrl)
 	d.Set("delegate_selectors", connector.TerraformCloud.DelegateSelectors)
+	d.Set("execute_on_delegate", connector.TerraformCloud.ExecuteOnDelegate)
 
 	switch connector.TerraformCloud.Credential.Type_ {
 	case nextgen.TerraformCloudAuthTypes.ApiToken:


### PR DESCRIPTION
**Title:** 
- Added missing execute on delegate field to Terraform Cloud Connector.
- Keep the backward compatibility for the existing connector configurations.

**Details:**
The execute_on_delegate field was missing in the Terraform Cloud Connector model, which could impact certain configurations. This update adds the field while ensuring that existing connectors continue to function as expected, maintaining backward compatibility.

**Impact**
- New configurations can now properly set execute_on_delegate.
- No breaking changes for users with existing connector setups.

**Testing**
- Verified that the new field is correctly handled in the model.
- Ensured that legacy configurations remain unaffected.

**Related Issues:**
N/A

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
