### PR TITLE
fix: [CDS-107596]: Change `force_delete` to Bool

### DIFF
--- a/docs/resources/platform_environment.md
+++ b/docs/resources/platform_environment.md
@@ -279,7 +279,7 @@ resource "harness_platform_environment" "example" {
 
 - `color` (String) Color of the environment.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of environments
+- `force_delete` (Boolean) When set to true, enables force deletion of environments.
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_environment_group.md
+++ b/docs/resources/platform_environment_group.md
@@ -81,7 +81,7 @@ resource "harness_platform_environment_group" "example" {
 ### Optional
 
 - `color` (String) Color of the environment group.
-- `force_delete` (String) Enable this flag for force deletion of environment group
+- `force_delete` (Boolean) When set to true, enables force deletion of environment group.
 - `org_id` (String) org_id of the environment group.
 - `project_id` (String) project_id of the environment group.
 

--- a/docs/resources/platform_infrastructure.md
+++ b/docs/resources/platform_infrastructure.md
@@ -170,7 +170,7 @@ resource "harness_platform_infrastructure" "test" {
 
 - `deployment_type` (String) Infrastructure deployment type. Valid values are Kubernetes, NativeHelm, Ssh, WinRm, ServerlessAwsLambda, AzureWebApp, Custom, ECS.
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of infrastructure
+- `force_delete` (Boolean) When set to true, enables force deletion of infrastructure.
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_service.md
+++ b/docs/resources/platform_service.md
@@ -271,7 +271,7 @@ resource "harness_platform_service" "example" {
 ### Optional
 
 - `description` (String) Description of the resource.
-- `force_delete` (String) Enable this flag for force deletion of service
+- `force_delete` (Boolean) When set to true, enables force deletion of the service.
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.

--- a/docs/resources/platform_template.md
+++ b/docs/resources/platform_template.md
@@ -1176,7 +1176,7 @@ resource "harness_platform_template" "test" {
 
 - `comments` (String) Specify comment with respect to changes.
 - `description` (String, Deprecated) Description of the entity. Description field is deprecated
-- `force_delete` (String) Enable this flag for force deletion of template. It will delete the Harness entity even if your pipelines or other entities reference it
+- `force_delete` (Boolean) When set to true, enables force deletion of the template. It will delete the Harness entity even if your pipelines or other entities reference it.
 - `git_details` (Block List, Max: 1) Contains parameters related to creating an Entity for Git Experience. (see [below for nested schema](#nestedblock--git_details))
 - `git_import_details` (Block List, Max: 1) Contains Git Information for importing entities from Git (see [below for nested schema](#nestedblock--git_import_details))
 - `import_from_git` (Boolean) Flag to set if importing from Git

--- a/internal/service/cd_nextgen/environment/resource_environment.go
+++ b/internal/service/cd_nextgen/environment/resource_environment.go
@@ -46,7 +46,7 @@ func ResourceEnvironment() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of environments",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
@@ -268,7 +268,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	_, httpResp, err := c.EnvironmentsApi.DeleteEnvironmentV2(ctx, d.Id(), c.AccountId, &nextgen.EnvironmentsApiDeleteEnvironmentV2Opts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
-		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete"),
+		ForceDelete:       helpers.BuildFieldBool(d, "force_delete"),
 	})
 
 	if err != nil {

--- a/internal/service/cd_nextgen/environment/resource_environment_test.go
+++ b/internal/service/cd_nextgen/environment/resource_environment_test.go
@@ -112,6 +112,7 @@ func TestAccResourceEnvironmentForceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
 					resource.TestCheckResourceAttr(resourceName, "project_id", id),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{

--- a/internal/service/cd_nextgen/environment_group/resource_environment_group.go
+++ b/internal/service/cd_nextgen/environment_group/resource_environment_group.go
@@ -53,7 +53,7 @@ func ResourceEnvironmentGroup() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of environment group",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
@@ -133,7 +133,7 @@ func resourceEnvironmentGroupDelete(ctx context.Context, d *schema.ResourceData,
 	_, httpResp, err := c.EnvironmentGroupApi.DeleteEnvironmentGroup(ctx, d.Id(), c.AccountId, &nextgen.EnvironmentGroupApiDeleteEnvironmentGroupOpts{
 		Branch:            helpers.BuildField(d, "branch"),
 		RepoIdentifier:    helpers.BuildField(d, "repo_id"),
-		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete"),
+		ForceDelete:       helpers.BuildFieldBool(d, "force_delete"),
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
 	})

--- a/internal/service/cd_nextgen/environment_group/resource_environment_group_test.go
+++ b/internal/service/cd_nextgen/environment_group/resource_environment_group_test.go
@@ -188,6 +188,7 @@ func TestAccResourceEnvironmentGroupForceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
 					resource.TestCheckResourceAttr(resourceName, "project_id", id),
 					resource.TestCheckResourceAttr(resourceName, "color", "#0063F7"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{

--- a/internal/service/cd_nextgen/infrastructure/resource_Infrastructure.go
+++ b/internal/service/cd_nextgen/infrastructure/resource_Infrastructure.go
@@ -55,7 +55,7 @@ func ResourceInfrastructure() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of infrastructure",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
@@ -286,7 +286,7 @@ func resourceInfrastructureDelete(ctx context.Context, d *schema.ResourceData, m
 	_, httpResp, err := c.InfrastructuresApi.DeleteInfrastructure(ctx, d.Id(), c.AccountId, env_id, &nextgen.InfrastructuresApiDeleteInfrastructureOpts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
-		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete"),
+		ForceDelete:       helpers.BuildFieldBool(d, "force_delete"),
 	})
 
 	if err != nil {

--- a/internal/service/cd_nextgen/infrastructure/resource_Infrastructure_test.go
+++ b/internal/service/cd_nextgen/infrastructure/resource_Infrastructure_test.go
@@ -73,6 +73,7 @@ func TestAccResourceInfrastructureForceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", "Kubernetes"),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
 					resource.TestCheckResourceAttr(resourceName, "project_id", id),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{
@@ -189,6 +190,7 @@ func TestAccResourceInfrastructureAccountLevelForceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", id),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", "Kubernetes"),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{
@@ -260,6 +262,7 @@ func TestAccResourceInfrastructureOrgLevelForceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", "Kubernetes"),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{

--- a/internal/service/cd_nextgen/service/resource_service.go
+++ b/internal/service/cd_nextgen/service/resource_service.go
@@ -33,7 +33,7 @@ func ResourceService() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of service",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
@@ -251,7 +251,7 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	_, httpResp, err := c.ServicesApi.DeleteServiceV2(ctx, d.Id(), c.AccountId, &nextgen.ServicesApiDeleteServiceV2Opts{
 		OrgIdentifier:     helpers.BuildField(d, "org_id"),
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
-		ForceDelete:       helpers.BuildFieldForBoolean(d, "force_delete"),
+		ForceDelete:       helpers.BuildFieldBool(d, "force_delete"),
 	})
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)

--- a/internal/service/cd_nextgen/service/resource_service_test.go
+++ b/internal/service/cd_nextgen/service/resource_service_test.go
@@ -299,6 +299,7 @@ func TestForceDeleteService(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "org_id", id),
 					resource.TestCheckResourceAttr(resourceName, "project_id", id),
+					resource.TestCheckResourceAttr(resourceName, "force_delete", "true"),
 				),
 			},
 			{

--- a/internal/service/pipeline/template/resource_template.go
+++ b/internal/service/pipeline/template/resource_template.go
@@ -115,7 +115,7 @@ func ResourceTemplate() *schema.Resource {
 			},
 			"force_delete": {
 				Description: "Enable this flag for force deletion of template. It will delete the Harness entity even if your pipelines or other entities reference it",
-				Type:        schema.TypeString,
+				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
@@ -564,19 +564,19 @@ func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta in
 		httpResp, err = c.ProjectTemplateApi.DeleteTemplateProject(ctx, project_id, id, org_id, version, &nextgen.ProjectTemplateApiDeleteTemplateProjectOpts{
 			HarnessAccount: optional.NewString(c.AccountId),
 			Comments:       helpers.BuildField(d, "comments"),
-			ForceDelete:    helpers.BuildFieldForBoolean(d, "force_delete"),
+			ForceDelete:    helpers.BuildFieldBool(d, "force_delete"),
 		})
 	} else if org_id != "" && project_id == "" {
 		httpResp, err = c.OrgTemplateApi.DeleteTemplateOrg(ctx, id, org_id, version, &nextgen.OrgTemplateApiDeleteTemplateOrgOpts{
 			HarnessAccount: optional.NewString(c.AccountId),
 			Comments:       helpers.BuildField(d, "comments"),
-			ForceDelete:    helpers.BuildFieldForBoolean(d, "force_delete"),
+			ForceDelete:    helpers.BuildFieldBool(d, "force_delete"),
 		})
 	} else {
 		httpResp, err = c.AccountTemplateApi.DeleteTemplateAcc(ctx, id, version, &nextgen.AccountTemplateApiDeleteTemplateAccOpts{
 			HarnessAccount: optional.NewString(c.AccountId),
 			Comments:       helpers.BuildField(d, "comments"),
-			ForceDelete:    helpers.BuildFieldForBoolean(d, "force_delete"),
+			ForceDelete:    helpers.BuildFieldBool(d, "force_delete"),
 		})
 
 	}


### PR DESCRIPTION
**Title**: [Schema] Change `force_delete` Field Type from String to Boolean

**Summary**: Changed the type of `force_delete` field from `String` to `Boolean` across multiple resources to improve type safety and maintain consistency with Terraform best practices. This change affects service, environment, environment group, template, and infrastructure resources.

**Details**:

1. Schema Changes:
   - Modified `force_delete` field type from schema.TypeString to schema.TypeBool
   - Updated helper function from `BuildFieldForBoolean` to `BuildFieldBool` for proper boolean handling
   - Maintained computed and optional attributes

2. Documentation Updates:
   - Updated field type documentation from String to Boolean
   - Improved description clarity for all affected resources
   - Added proper punctuation and consistent formatting
 
3. Test Updates:
   - Added boolean value verification in test cases
   - Maintained `ImportStateVerifyIgnore` for `force_delete` field

4. Affected Resources:
   - Platform Service
   - Platform Environment
   - Platform Environment Group
   - Platform Template
   - Platform Infrastructure

The changes are backward compatible as the previous string values "true"/"false" will be automatically handled by Terraform's type conversion.

**Related Issues:**
[CDS-107596](https://harness.atlassian.net/browse/CDS-107596)



[CDS-107596]: https://harness.atlassian.net/browse/CDS-107596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ