### PR TITLE
doc: [PIPE-25771] Update version field documentation to match version…

### DIFF
--- a/docs/resources/platform_template.md
+++ b/docs/resources/platform_template.md
@@ -1099,7 +1099,7 @@ resource "time_sleep" "wait_10_seconds" {
   destroy_duration = "10s"
 }
 
-##Importing Account Level Templates
+## Importing Account Level Templates
 resource "harness_platform_template" "test" {
   identifier      = "accounttemplate"
   name            = "accounttemplate"
@@ -1119,7 +1119,7 @@ resource "harness_platform_template" "test" {
   }
 }
 
-##Importing Org Level Templates
+## Importing Org Level Templates
 resource "harness_platform_template" "test" {
   identifier      = "orgtemplate"
   name            = "orgtemplate"
@@ -1140,7 +1140,7 @@ resource "harness_platform_template" "test" {
   }
 }
 
-##Importing Project Level Templates
+## Importing Project Level Templates
 resource "harness_platform_template" "test" {
   identifier      = "projecttemplate"
   name            = "projecttemplate"
@@ -1170,7 +1170,7 @@ resource "harness_platform_template" "test" {
 
 - `identifier` (String) Unique identifier of the resource
 - `name` (String) Name of the Variable
-- `version` (String) Version Label for Template.
+- `version` (String) Version Label for Template. This should match the `versionLabel` specified in the template YAML.
 
 ### Optional
 


### PR DESCRIPTION
## [Documentation]: Update Template Version Field Documentation

## Summary
This PR updates the documentation for the `version` field in the Platform Template resource to clarify that it should match the `versionLabel` specified in the template YAML. This change helps prevent confusion and ensures proper template configuration.

## Details
- Updated the documentation in `docs/resources/platform_template.md`
- Added clarification that the `version` field value should match the `versionLabel` in the template YAML
- This change improves user experience by making the relationship between these fields explicit
- No functional changes, documentation update only

## Related Issues
- [PIPE-25771](https://harness.atlassian.net/browse/PIPE-25771)

The PR is focused on documentation improvement to help users correctly configure template versions in Harness Platform Templates.

**Screenshots:**
- Before
<img width="686" alt="image" src="https://github.com/user-attachments/assets/f9f03472-cf60-4cdf-9ca3-cae0daaa5103" />

- After
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/172db582-311b-4e7f-9069-390c522d2e5a" />



[PIPE-25771]: https://harness.atlassian.net/browse/PIPE-25771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ