### PR TITLE
fix: [CDS-106112]: fix constant diff on gitops cluster bearer token

### DIFF
--- a/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
+++ b/internal/service/platform/gitops/cluster/resource_gitops_cluster.go
@@ -133,6 +133,7 @@ func ResourceGitopsCluster() *schema.Resource {
 													Type:        schema.TypeString,
 													Sensitive:   true,
 													Optional:    true,
+													Computed:    true,
 												},
 												"tls_client_config": {
 													Description: "Settings to enable transport layer security.",
@@ -442,6 +443,13 @@ func resourceGitopsClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		d.MarkNewResource()
 		return nil
 	}
+
+	if attr, ok := d.GetOk("request.0.cluster.0.config.0.bearer_token"); ok {
+		if resp.Cluster.Config != nil && len(resp.Cluster.Config.BearerToken) != 0 {
+			resp.Cluster.Config.BearerToken = attr.(string)
+		}
+	}
+
 	setClusterDetails(d, &resp)
 	return nil
 }
@@ -466,6 +474,12 @@ func resourceGitopsClusterRead(ctx context.Context, d *schema.ResourceData, meta
 		d.SetId("")
 		d.MarkNewResource()
 		return nil
+	}
+
+	if attr, ok := d.GetOk("request.0.cluster.0.config.0.bearer_token"); ok {
+		if resp.Cluster.Config != nil && len(resp.Cluster.Config.BearerToken) != 0 {
+			resp.Cluster.Config.BearerToken = attr.(string)
+		}
 	}
 	setClusterDetails(d, &resp)
 	return nil
@@ -499,6 +513,13 @@ func resourceGitopsClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 		d.MarkNewResource()
 		return nil
 	}
+
+	if attr, ok := d.GetOk("request.0.cluster.0.config.0.bearer_token"); ok {
+		if resp.Cluster.Config != nil && len(resp.Cluster.Config.BearerToken) != 0 {
+			resp.Cluster.Config.BearerToken = attr.(string)
+		}
+	}
+	
 	setClusterDetails(d, &resp)
 	return nil
 }


### PR DESCRIPTION
**Title:** Fix constant diff on gitops cluster bearer token field

**Summary:**
Since Gitops Clusters REST API's never return actual secret value of the clusters bearer token, and instead returns a masked value (********), this field constantly reports a diff unless 
```
lifecycle {
    ignore_changes = [
      request.0.upsert, request.0.cluster.0.config.0.bearer_token,
    ]
}
```
like in this given example https://registry.terraform.io/providers/harness/harness/latest/docs/resources/platform_gitops_cluster#example-usage is provided, this PR should fix this now by setting the tfstate to the value provided by user and leaves it upto the user to manage their tfstate properly to handle secrets similar to how we are handling for gitops repository currently.


Testing:
[SCENARIO]: Cluster created with old version of provider exists.

* Provider version updated: OK
* first "tf apply" after removing the lifecycle ignore_changes block and updating provider: OK
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/ad3d417b-e55f-4a5c-b1b2-4fd02d9455aa" />
* subsequent plan and applies afterwards: OK
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/f8a6902c-4ab7-4182-b030-e69422a58a42" />

* now change bearer_token to wrong one and plan, reports correct diff: OK
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/cbdbdb73-8ef1-44c0-a0a8-06c9f85774f1" />

* updated to wrong bearer_token, (update is good): OK
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/b01d457f-dc5d-494e-8c73-0fa40cbe08b6" />



<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
