### PR TITLE
fix: [PIPE-26148]: Fix Policy Recreation

### DIFF
--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"github.com/harness/harness-go-sdk/harness/policymgmt"
 	"net/http"
 
 	"github.com/harness/harness-go-sdk/harness/nextgen"
@@ -32,6 +33,28 @@ func HandleDBOpsApiError(err error, d *schema.ResourceData, httpResp *http.Respo
 		}
 		if httpResp.StatusCode == 404 {
 			return diag.Errorf("resource with ID %s not found: %v", d.Id(), erro.Error())
+		}
+	}
+
+	return diag.Errorf(err.Error())
+}
+
+func HandlePolicyApiError(err error, d *schema.ResourceData, httpResp *http.Response) diag.Diagnostics {
+	_, ok := err.(policymgmt.GenericSwaggerError)
+	if ok && httpResp != nil {
+		if httpResp.StatusCode == 401 {
+			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
+				"1) Please check if token has expired or is wrong.\n" +
+				"2) Harness Provider is misconfigured. For firstgen resources please give the correct api_key and for nextgen resources please give the correct platform_api_key.")
+		}
+		if httpResp.StatusCode == 403 {
+			return diag.Errorf(httpResp.Status + "\n" + "Hint:\n" +
+				"1) Please check if the token has required permission for this operation.\n" +
+				"2) Please check if the token has expired or is wrong.")
+		}
+		if httpResp.StatusCode == 404 {
+			d.SetId("")
+			return nil
 		}
 	}
 

--- a/internal/service/platform/policyset/resource_policyset.go
+++ b/internal/service/platform/policyset/resource_policyset.go
@@ -91,7 +91,7 @@ func resourcePolicysetRead(ctx context.Context, d *schema.ResourceData, meta int
 	policy, httpResp, err := c.PolicysetsApi.PolicysetsFind(ctx, id, &localVarOptionals)
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandlePolicyApiError(err, d, httpResp)
 	}
 
 	readPolicyset(d, policy)
@@ -207,7 +207,7 @@ func resourcePolicysetDelete(ctx context.Context, d *schema.ResourceData, meta i
 	httpResp, err := c.PolicysetsApi.PolicysetsDelete(ctx, d.Id(), &localVarOptionals)
 
 	if err != nil {
-		return helpers.HandleApiError(err, d, httpResp)
+		return helpers.HandlePolicyApiError(err, d, httpResp)
 	}
 
 	return nil


### PR DESCRIPTION
**Title:** Fix Policy Recreation

**Summary:**
Fix Policy Recreation

**Details:**
Fix Policy Recreation

**Related Issues:**
Ticket : [PIPE-26148](https://harness.atlassian.net/browse/PIPE-26148)

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
