### PR TITLE
fix: [CDS-109153]: Fix GitOps Application Multi-Source Configuration in Terraform Provider

### DIFF
--- a/.changelog/1225.txt
+++ b/.changelog/1225.txt
@@ -1,0 +1,2 @@
+```release-note:fix
+resource: platform_gitops_applications: Fixed multi-source GitOps application configuration handling. This resolves the issue with "Invalid address to set" errors when using multiple sources in GitOps applications.```

--- a/internal/service/platform/gitops/applications/datasource_gitops_applications.go
+++ b/internal/service/platform/gitops/applications/datasource_gitops_applications.go
@@ -2,7 +2,6 @@ package applications
 
 import (
 	"context"
-
 	"github.com/antihax/optional"
 	"github.com/harness/harness-go-sdk/harness/nextgen"
 	"github.com/harness/terraform-provider-harness/helpers"
@@ -53,6 +52,14 @@ func DataSourceGitopsApplications() *schema.Resource {
 				Description: "Repository identifier of the GitOps application.",
 				Type:        schema.TypeString,
 				Computed:    true,
+			},
+			"repo_ids": {
+				Description: "List of repository identifiers of the GitOps for Multi-Source application. Not required if skipRepoValidation is set to true.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"upsert": {
 				Description: "Indicates if the GitOps application should be updated if existing and inserted if not.",
@@ -740,6 +747,26 @@ func DataSourceGitopsApplications() *schema.Resource {
 																		},
 																	},
 																},
+															},
+															"ignore_missing_value_files": {
+																Description: "Prevents 'helm template' from failing when value_files do not exist locally.",
+																Type:        schema.TypeBool,
+																Optional:    true,
+															},
+															"skip_crds": {
+																Description: "Indicates if to skip CRDs during helm template. Corresponds to helm --skip-crds",
+																Type:        schema.TypeBool,
+																Optional:    true,
+															},
+															"skip_tests": {
+																Description: "Indicates if to skip tests during helm template. Corresponds to helm --skip-tests",
+																Type:        schema.TypeBool,
+																Optional:    true,
+															},
+															"skip_schema_validation": {
+																Description: "Indicates if to skip schema validation during helm template. Corresponds to helm --skip-schema-validation",
+																Type:        schema.TypeBool,
+																Optional:    true,
 															},
 														},
 													},

--- a/internal/service/platform/gitops/applications/datasource_gitops_applications_test.go
+++ b/internal/service/platform/gitops/applications/datasource_gitops_applications_test.go
@@ -181,6 +181,75 @@ func testAccDataSourceGitopsApplication(id string, accountId string, name string
 			agent_id = "%[4]s"
 			name = "%[3]s"
 		}
+
+		resource "harness_platform_gitops_applications" "testmultisource" {
+			depends_on = [harness_platform_gitops_repository.test, harness_platform_gitops_cluster.test]
+			application {
+				metadata {
+					annotations = {}
+					labels = {
+						"harness.io/serviceRef" = harness_platform_service.test.id
+						"harness.io/envRef" = harness_platform_environment.test.id
+					}
+					name = "%[1]s-ms"
+				}
+				spec {
+					sync_policy {
+						sync_options = [
+							"PrunePropagationPolicy=undefined",
+							"CreateNamespace=false",
+							"Validate=false",
+							"skipSchemaValidations=false",
+							"autoCreateNamespace=false",
+							"pruneLast=false",
+							"applyOutofSyncOnly=false",
+							"Replace=false",
+							"retry=false"
+						]
+					}
+					sources {
+							repo_url = "%[9]s"
+							target_revision = "master"
+							ref = "val"
+					}
+					sources {
+							repo_url = "%[9]s"
+							target_revision = "master"
+							path = "helm-guestbook"
+							helm {
+							  value_files = [
+								"$val/helm-guestbook/values.yaml"
+							  ]
+							}
+					}
+					destination {
+						namespace = "%[6]s"
+						server = "%[7]s"
+					}
+				}
+			}
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+			account_id = "%[2]s"
+			identifier = "%[1]s-ms"
+			name = "%[3]s-ms"
+			cluster_id = "%[8]s"
+			repo_ids = [
+				"%[1]s",
+				"%[1]s"
+			]
+			agent_id = "%[4]s"
+		}
+
+		data "harness_platform_gitops_applications" "testms"{
+			depends_on = [harness_platform_gitops_applications.testmultisource]
+			identifier = "%[1]s-ms"
+			account_id = "%[2]s"
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+			agent_id = "%[4]s"
+			name = "%[3]s-ms"
+		}
 		`, id, accountId, name, agentId, clusterName, namespace, clusterServer, clusterId, repo, repoId, clusterToken)
 
 }

--- a/internal/service/platform/gitops/applications/resource_gitops_applications_test.go
+++ b/internal/service/platform/gitops/applications/resource_gitops_applications_test.go
@@ -57,6 +57,50 @@ func TestAccResourceGitopsApplication_HelmApp(t *testing.T) {
 	})
 }
 
+func TestAccResourceGitopsApplication_HelmAppMultiSource(t *testing.T) {
+	id := strings.ToLower(fmt.Sprintf("%s%s", t.Name(), utils.RandStringBytes(5)))
+	id = strings.ReplaceAll(id, "_", "")
+	name := id
+	agentId := os.Getenv("HARNESS_TEST_GITOPS_AGENT_ID")
+	accountId := os.Getenv("HARNESS_ACCOUNT_ID")
+	clusterServer := os.Getenv("HARNESS_TEST_GITOPS_CLUSTER_SERVER")
+	clusterToken := os.Getenv("HARNESS_TEST_GITOPS_CLUSTER_TOKEN")
+
+	clusterId := id
+	repoId := id
+	clusterName := id
+	namespace := "test"
+	repo := os.Getenv("HARNESS_TEST_GITOPS_REPO")
+	namespaceUpdated := namespace + "_updated"
+	resourceName := "harness_platform_gitops_applications.testmultisource"
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccResourceGitopsApplicationDestroy(resourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGitopsApplicationHelmMultiSource(id, accountId, name, agentId, clusterName, namespace, clusterServer, clusterId, repo, repoId, clusterToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccResourceGitopsApplicationHelmMultiSource(id, accountId, name, agentId, clusterName, namespaceUpdated, clusterServer, clusterId, repo, repoId, clusterToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "application.0.spec.0.destination.0.namespace", namespaceUpdated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.GitopsAgentProjectLevelResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceGitopsApplication_KustomizeApp(t *testing.T) {
 	id := strings.ToLower(fmt.Sprintf("%s%s", t.Name(), utils.RandStringBytes(5)))
 	id = strings.ReplaceAll(id, "_", "")
@@ -215,7 +259,7 @@ func testAccGetApplication(resourceName string, state *terraform.State) (*nextge
 	agentIdentifier := r.Primary.Attributes["agent_id"]
 	orgIdentifier := r.Primary.Attributes["org_id"]
 	projectIdentifier := r.Primary.Attributes["project_id"]
-	queryName := r.Primary.Attributes["identifier"]
+	queryName := r.Primary.Attributes["name"]
 	repoIdentifier := r.Primary.Attributes["repo_id"]
 
 	resp, _, err := c.ApplicationsApiService.AgentApplicationServiceGet(ctx, agentIdentifier, queryName, c.AccountId, orgIdentifier, projectIdentifier, &nextgen.ApplicationsApiAgentApplicationServiceGetOpts{
@@ -242,11 +286,11 @@ func testAccResourceGitopsApplicationHelm(id string, accountId string, name stri
 		}
 
 		resource "harness_platform_service" "test" {
-      		identifier = "%[1]s"
-      		name = "%[3]s"
-      		org_id = harness_platform_project.test.org_id
-      		project_id = harness_platform_project.test.id
-    	}
+			identifier = "%[1]s"
+			name = "%[3]s"
+			org_id = harness_platform_project.test.org_id
+			project_id = harness_platform_project.test.id
+		}
 		resource "harness_platform_environment" "test" {
 			identifier = "%[1]s"
 			name = "%[3]s"
@@ -254,7 +298,7 @@ func testAccResourceGitopsApplicationHelm(id string, accountId string, name stri
 			project_id = harness_platform_project.test.id
 			tags = ["foo:bar", "baz"]
 			type = "PreProduction"
-  		}
+		}
 
 		resource "harness_platform_gitops_repository" "test" {
 			identifier = "%[1]s"
@@ -264,9 +308,9 @@ func testAccResourceGitopsApplicationHelm(id string, accountId string, name stri
 			agent_id = "%[4]s"
 			repo {
 					repo = "https://github.com/harness-apps/hosted-gitops-example-apps"
-        			name = "%[1]s"
-        			insecure = true
-        			connection_type = "HTTPS_ANONYMOUS"
+					name = "%[1]s"
+					insecure = true
+					connection_type = "HTTPS_ANONYMOUS"
 			}
 			upsert = true
 		}
@@ -318,6 +362,136 @@ func testAccResourceGitopsApplicationHelm(id string, accountId string, name stri
 			name = "%[3]s"
 		}
 		`, id, accountId, name, agentId, clusterName, namespace, clusterServer, clusterId, repo, repoId)
+}
+
+func testAccResourceGitopsApplicationHelmMultiSource(id string, accountId string, name string, agentId string, clusterName string, namespace string, clusterServer string, clusterId string, repo string, repoId string, clusterToken string) string {
+	return fmt.Sprintf(`
+		resource "harness_platform_organization" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+		}
+
+		resource "harness_platform_project" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+			org_id = harness_platform_organization.test.id
+		}
+
+		resource "harness_platform_service" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+			org_id = harness_platform_project.test.org_id
+			project_id = harness_platform_project.test.id
+		}
+		resource "harness_platform_environment" "test" {
+			identifier = "%[1]s"
+			name = "%[3]s"
+			org_id = harness_platform_project.test.org_id
+			project_id = harness_platform_project.test.id
+			tags = ["foo:bar", "baz"]
+			type = "PreProduction"
+		}
+
+		resource "harness_platform_gitops_repository" "test" {
+			identifier = "%[1]s"
+			account_id = "%[2]s"
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+			agent_id = "%[4]s"
+			repo {
+					repo = "https://github.com/harness-apps/hosted-gitops-example-apps"
+					name = "%[1]s"
+					insecure = true
+					connection_type = "HTTPS_ANONYMOUS"
+			}
+			upsert = true
+		}
+
+		resource "harness_platform_gitops_cluster" "test" {
+			identifier = "%[8]s"
+			account_id = "%[2]s"
+			agent_id = "%[4]s"
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+			request {
+				upsert = true
+				cluster {
+					server = "%[7]s"
+					name = "%[8]s"
+					config {
+						bearer_token = "%[11]s"
+						tls_client_config {
+							insecure = true
+						}
+						cluster_connection_type = "SERVICE_ACCOUNT"
+					}
+				}
+			}
+			lifecycle {
+				ignore_changes = [
+					request.0.upsert, request.0.cluster.0.config.0.bearer_token, request.0.cluster.0.info,
+				]
+			}
+		}
+
+		resource "harness_platform_gitops_applications" "testmultisource" {
+			depends_on = [harness_platform_gitops_repository.test, harness_platform_gitops_cluster.test, harness_platform_service.test, harness_platform_environment.test, harness_platform_project.test, harness_platform_organization.test]
+			application {
+				metadata {
+					annotations = {}
+					labels = {
+						"harness.io/serviceRef" = harness_platform_service.test.id
+						"harness.io/envRef" = harness_platform_environment.test.id
+					}
+					name = "%[1]s"
+				}
+				spec {
+					sync_policy {
+						sync_options = [
+							"PrunePropagationPolicy=undefined",
+							"CreateNamespace=false",
+							"Validate=false",
+							"skipSchemaValidations=false",
+							"autoCreateNamespace=false",
+							"pruneLast=false",
+							"applyOutofSyncOnly=false",
+							"Replace=false",
+							"retry=false"
+						]
+					}
+					sources {
+							repo_url = "%[9]s"
+							target_revision = "master"
+							ref = "val"
+					}
+					sources {
+							repo_url = "%[9]s"
+							target_revision = "master"
+							path = "helm-guestbook"
+							helm {
+							  value_files = [
+								"$val/helm-guestbook/values.yaml"
+							  ]
+							}
+					}
+					destination {
+						namespace = "%[6]s"
+						server = "%[7]s"
+					}
+				}
+			}
+			project_id = harness_platform_project.test.id
+			org_id = harness_platform_organization.test.id
+			account_id = "%[2]s"
+			name = "%[3]s"
+			cluster_id = "%[8]s"
+			repo_ids = [
+				"%[1]s",
+				"%[1]s"
+			]
+			agent_id = "%[4]s"
+		}
+		`, id, accountId, name, agentId, clusterName, namespace, clusterServer, clusterId, repo, repoId, clusterToken)
 }
 
 func testAccResourceGitopsApplicationHelmSkipRepoValidation(id string, accountId string, name string, agentId string, clusterName string, namespace string, clusterServer string, clusterId string, repoURL string, chart string, skipRepoValidation bool) string {


### PR DESCRIPTION
**Title:** Fix GitOps Application Multi-Source Configuration in Terraform Provider

**Summary:**
This PR fixes the handling of multi-source configurations in GitOps applications by properly implementing state management for multiple sources and their associated configurations.

**Details:**
- Added `getSourcesForState` method to properly handle multi-source applications state management
- Fixed value type conversions and null checks for source parameters
- Added schema validation for multi-source specific fields like `ref`
- Added support for Helm-specific fields in multi-source context:
  - ignore_missing_value_files
  - skip_crds
  - skip_tests 
  - skip_schema_validation

**Why is the change needed:** 
We were getting the error - "error setting application: Invalid address to set: []string{\"application\", \"0\", \"spec\", \"0\", \"sources\", \"0\", \"Chart\"}" - due to improper handling while updating the state. 
The resource creation would succeed, but setting in state was failing, leading to issues later.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. 
 Verified
- Execute terraform apply again without any changes. 
 Verified
- Update the resource and execute terraform apply. 
Verified
- Remove the content from resource file and execute terraform apply. 
Verified
- Add again the resource and execute the terraform apply. 
Verified
- Verify the import the resource file is working fine.
Verified
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
![image](https://github.com/user-attachments/assets/a1ae69d0-8f9b-42f4-ae22-a9c543e2f2a0)
<img width="883" alt="image" src="https://github.com/user-attachments/assets/729bc104-0ada-4309-ae93-d482b3f6d8f4" />

**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
