### PR TITLE
[DBOPS-1073]: Removing instance count and adding conflictwith

### DIFF
--- a/docs/resources/platform_db_schema.md
+++ b/docs/resources/platform_db_schema.md
@@ -84,8 +84,6 @@ resource "harness_platform_db_schema" "test" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `schema_source_type` (String) Type of the schema source.
-- `instance_count` (Number) Number of database instances corresponding to database schema.
 
 <a id="nestedblock--schema_source"></a>
 ### Nested Schema for `schema_source`

--- a/internal/service/platform/db_schema/resource_db_schema.go
+++ b/internal/service/platform/db_schema/resource_db_schema.go
@@ -37,11 +37,12 @@ func ResourceDBSchema() *schema.Resource {
 				Optional:     true,
 			},
 			"schema_source": {
-				Description:  "Provides a connector and path at which to find the database schema representation",
-				Type:         schema.TypeList,
-				MaxItems:     1,
-				Optional:     true,
-				AtLeastOneOf: []string{"schema_source", "changelog_script"},
+				Description:   "Provides a connector and path at which to find the database schema representation",
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
+				ConflictsWith: []string{"changelog_script"},
+				AtLeastOneOf:  []string{"schema_source", "changelog_script"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connector": {
@@ -68,11 +69,12 @@ func ResourceDBSchema() *schema.Resource {
 				},
 			},
 			"changelog_script": {
-				Description:  "Configuration to clone changeSets using script",
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				AtLeastOneOf: []string{"schema_source", "changelog_script"},
+				Description:   "Configuration to clone changeSets using script",
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"schema_source"},
+				AtLeastOneOf:  []string{"schema_source", "changelog_script"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"image": {


### PR DESCRIPTION
[DBOPS-1073]: Removing instance count and adding conflictwith for schema source and script


**Summary:**
instance_count is added in docs but not needed here as it not a mandatory field. 
adding conflictWith with schema-source and script as we are expecting one at anytime

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
Reference any related issues or tickets 

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`


[DBOPS-1073]: https://harness.atlassian.net/browse/DBOPS-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ