### PR TITLE
Update platform_connector_kubernetes_cloud_cost.md

### DIFF
--- a/docs/resources/platform_connector_kubernetes_cloud_cost.md
+++ b/docs/resources/platform_connector_kubernetes_cloud_cost.md
@@ -10,6 +10,8 @@ description: |-
 
 Resource for creating a Kubernetes Cloud Cost connector.
 
+These conectors need to be created at the account level in Harness.
+
 ## Example Usage
 
 ```terraform
@@ -29,7 +31,7 @@ resource "harness_platform_connector_kubernetes_cloud_cost" "example" {
 
 ### Required
 
-- `connector_ref` (String) Reference of the Connector. To reference a connector at the organization scope, prefix 'org' to the expression: org.{identifier}. To reference a connector at the account scope, prefix 'account` to the expression: account.{identifier}.
+- `connector_ref` (String) Reference to a Kubernetes connector also at the account level.
 - `features_enabled` (Set of String) Indicates which feature to enable among Billing, Optimization, and Visibility.
 - `identifier` (String) Unique identifier of the resource.
 - `name` (String) Name of the resource.
@@ -37,8 +39,6 @@ resource "harness_platform_connector_kubernetes_cloud_cost" "example" {
 ### Optional
 
 - `description` (String) Description of the resource.
-- `org_id` (String) Unique identifier of the organization.
-- `project_id` (String) Unique identifier of the project.
 - `tags` (Set of String) Tags to associate with the resource.
 
 ### Read-Only
@@ -52,10 +52,4 @@ Import is supported using the following syntax:
 ```shell
 # Import account level kubernetes cloud cost connector 
 terraform import harness_platform_connector_kubernetes_cloud_cost.example <connector_id>
-
-# Import org level kubernetes cloud cost connector 
-terraform import harness_platform_connector_kubernetes_cloud_cost.example <ord_id>/<connector_id>
-
-# Import project level kubernetes cloud cost connector 
-terraform import harness_platform_connector_kubernetes_cloud_cost.example <org_id>/<project_id>/<connector_id>
 ```


### PR DESCRIPTION
**Title:** [Chore] platform_connector_kubernetes_cloud_cost docs change

**Summary:**
The docs for this reasource make it seem like you can use this connector at the org/project level. This connector can only be used at the account level.

**Details:**
Remove all wording referencing org/proj level. Add clause about making this connector at the account level

**Related Issues:**
Customers were getting confused by the references to org/proj

**Testing Instructions:**
Describe how the changes were tested. Include any test cases or steps to verify the functionality.
Please include the below test scenario with your changes.
- Create the resource and execute terraform apply. (Verify the resource is created)
- Execute terraform apply again without any changes. (Verify no changes should be done)
- Update the resource and execute terraform apply. (Verify the resource updated successfully)
- Remove the content from resource file and execute terraform apply. (Verify the resource has been deleted)
- Add again the resource and execute the terraform apply. (Verify the resource is created)
- Verify the import the resource file is working fine.
- In case of remote entity, Verify for both default and non default branch.

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
