### PR TITLE
feat: [IAC-3539]: support multiple connectors for workspace in terraf…

### DIFF
--- a/docs/data-sources/platform_workspace.md
+++ b/docs/data-sources/platform_workspace.md
@@ -52,6 +52,7 @@ data "harness_platform_workspace" "test" {
 - `repository_path` (String) Repository Path is the path in which the infra code resides
 - `terraform_variable` (Block Set) Terraform variables configured on the workspace (see [below for nested schema](#nestedblock--terraform_variable))
 - `terraform_variable_file` (Block Set) Terraform variables files configured on the workspace (see [below for nested schema](#nestedblock--terraform_variable_file))
+- `connector` (Block Set) Provider connector configured on the workspace (see [below for nested schema](#nestedblock--connector))
 
 <a id="nestedblock--environment_variable"></a>
 ### Nested Schema for `environment_variable`
@@ -84,3 +85,12 @@ Read-Only:
 - `repository_connector` (String) Repository connector is the reference to the connector used to fetch the variables.
 - `repository_path` (String) Repository path is the path in which the variables reside.
 - `repository_sha` (String) Repository commit is SHA to fetch the variables from. This cannot be set if repository branch or commit is set.
+
+
+<a id="nestedblock--connector"></a>
+### Nested Schema for `connector`
+
+Read-Only:
+
+- `connector_ref` (String) Unique identifier of the connector.
+- `type` (String) Type indicates the type of the connector. Currently we support aws, azure, gcp.

--- a/docs/resources/platform_workspace.md
+++ b/docs/resources/platform_workspace.md
@@ -89,7 +89,6 @@ resource "harness_platform_workspace" "example" {
 - `name` (String) Name of the resource.
 - `org_id` (String) Unique identifier of the organization.
 - `project_id` (String) Unique identifier of the project.
-- `provider_connector` (String) Provider connector is the reference to the connector for the infrastructure provider
 - `provisioner_type` (String) Provisioner type defines the provisioning tool to use (terraform or opentofu)
 - `provisioner_version` (String) Provisioner version defines the provisioner version to use. The latest version of Opentofu should always be supported, Terraform is only supported up to version 1.5.7.
 - `repository` (String) Repository is the name of the repository to fetch the code from.
@@ -98,6 +97,7 @@ resource "harness_platform_workspace" "example" {
 
 ### Optional
 
+- `provider_connector` (String) Provider connector is the reference to the connector for the infrastructure provider
 - `default_pipelines` (Map of String) Default pipelines associated with this workspace
 - `description` (String) Description of the resource.
 - `environment_variable` (Block Set) Environment variables configured on the workspace (see [below for nested schema](#nestedblock--environment_variable))
@@ -108,6 +108,7 @@ resource "harness_platform_workspace" "example" {
 - `terraform_variable` (Block Set) Terraform variables configured on the workspace. Terraform variable keys must be unique within the workspace. (see [below for nested schema](#nestedblock--terraform_variable))
 - `terraform_variable_file` (Block Set) Terraform variables files configured on the workspace (see [below for nested schema](#nestedblock--terraform_variable_file))
 - `variable_sets` (List of String) Variable sets to use.
+- `connector` (Block Set) Provider connector configured on the workspace (see [below for nested schema](#nestedblock--connector))
 
 ### Read-Only
 
@@ -147,6 +148,14 @@ Optional:
 - `repository_commit` (String) Repository commit is tag to fetch the variables from. This cannot be set if repository branch or sha is set.
 - `repository_path` (String) Repository path is the path in which the variables reside.
 - `repository_sha` (String) Repository commit is SHA to fetch the variables from. This cannot be set if repository branch or commit is set.
+
+<a id="nestedblock--connector"></a>
+### Nested Schema for `connector`
+
+Required:
+
+- `connector_ref` (String) Unique identifier of the connector.
+- `type` (String) Type indicates the type of the connector. Currently we support aws, azure, gcp.
 
 ## Import
 

--- a/internal/service/platform/workspace/data_source_workspace.go
+++ b/internal/service/platform/workspace/data_source_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceWorkspace() *schema.Resource {
@@ -192,6 +193,26 @@ func DataSourceWorkspace() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+				},
+			},
+			"connector": {
+				Description: "Provider connectors configured on the Workspace. Only one connector of a type is supported",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connector_ref": {
+							Description: "Connector Ref is the reference to the connector",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"type": {
+							Description:  "Type is the connector type of the connector. Supported types: aws, azure, gcp",
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"aws", "azure", "gcp"}, false),
+						},
+					},
 				},
 			},
 		},

--- a/internal/service/platform/workspace/resource_workspace_test.go
+++ b/internal/service/platform/workspace/resource_workspace_test.go
@@ -235,5 +235,32 @@ func testAccResourceWorkspace(id string, name string, repositoryType string) str
   			}			
 			variable_sets = [harness_platform_infra_variable_set.test.id]
   		}
+
+		resource "harness_platform_workspace" "withMuptipleConnectors" {
+			identifier = "w%[1]s"
+			name = "w%[2]s"
+			org_id = harness_platform_organization.test.id
+			project_id = harness_platform_project.test.id
+			description = "description"
+			provisioner_type        = "terraform"
+			provisioner_version     = "1.5.6"
+			repository              = "https://github.com/org/repo"
+			%[3]s
+			repository_path         = "tf/aws/basic"
+			cost_estimation_enabled = true
+			repository_connector    = "account.${harness_platform_connector_github.test.id}"
+			connector {
+				connector_ref = "con1"
+				type = "aws"
+			}
+			connector {
+				connector_ref = "con2"
+				type = "azure"
+			}
+			connector {
+				connector_ref = "con3"
+				type = "gcp"
+			}
+  		}
 `, id, name, repositoryX)
 }


### PR DESCRIPTION

**Title:** [IAC-3539] support multiple connectors for workspace

**Summary:**
support multiple connectors for IAC workspace

**Details:**
Iac Workspace needs to support multiple provider connectors instead of only one. I've added an optional field `connctor` in order to provide the set of connectors

**Related Issues:**
[Reference any related issues or tickets](https://harness.atlassian.net/browse/IAC-3539) 

**Testing Instructions:**
- Created Workspace with provider_connector field
- Update Workspace with multiple connectors and check the terraform changes to reflect the new connectors to be added
- Update Workspace with multiple connectors with different connector types and check the terraform changes to reflect the connectors to be updated
- Update Workspace with provider_connector field and check the terraform changes to reflect the connectors to be removed

**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`


[IAC-3539]: https://harness.atlassian.net/browse/IAC-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ