### PR TITLE
fix: [PL-63020]: Handled 404 for  remove missing resource from state

### DIFF
--- a/internal/service/platform/resource_group/resource_group.go
+++ b/internal/service/platform/resource_group/resource_group.go
@@ -147,6 +147,12 @@ func resourceResourceGroupRead(ctx context.Context, d *schema.ResourceData, meta
 		ProjectIdentifier: helpers.BuildField(d, "project_id"),
 	})
 
+	// This tells TF the resource-group no longer exists
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return helpers.HandleApiError(err, d, httpResp)
 	}
@@ -158,7 +164,6 @@ func resourceResourceGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	readResourceGroup(d, resp.Data.ResourceGroup)
 
 	return nil
-
 }
 
 func resourceResourceGroupCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
When a resource group is deleted externally (e.g. from the Harness UI), the provider
previously failed during terraform plan/apply/destroy due to a 404 error from the API.

This commit updates `resourceResourceGroupRead` to check for a 404 response
and call `d.SetId("")`, which tells Terraform to remove the resource from the state.

This allows Terraform to recover gracefully from out-of-band deletions and improves user experience.
