### PR TITLE
fix: [FFM-12475]: resolve api key not listed issue

### DIFF
--- a/internal/service/platform/ff_api_key/resource_ff_api_key.go
+++ b/internal/service/platform/ff_api_key/resource_ff_api_key.go
@@ -150,7 +150,7 @@ func resourceFFApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("API key creation failed: %v", err)
 	}
 
-	d.SetId(resp.Identifier)
+	readFFApiKey(d, &resp, qp)
 
 	return nil
 }


### PR DESCRIPTION
**Title:** [Component/Feature] 
After creation the api key was not being set in state correctly due to [this pr](https://github.com/harness/terraform-provider-harness/commit/7f432b5f60835f78d576595f3a51293d0299aee0#diff-5e4b1341bc69d6cc722bd1ebb38a046a2b843cafc16e781bb3586356a0cac14eR153)

**Summary:**
Add back reading the response values after the create call

**Details:**
Explain the changes in detail, including any relevant context or background information.

**Related Issues:**
FFM-12475

