### PR TITLE
feat: [PIPE-28924]: Fix identifier field to prevent changes and validate YAML consistency

### DIFF
--- a/docs/resources/platform_template.md
+++ b/docs/resources/platform_template.md
@@ -1168,7 +1168,7 @@ resource "harness_platform_template" "test" {
 
 ### Required
 
-- `identifier` (String) Unique identifier of the resource
+- `identifier` (String) Unique identifier of the resource. Changing this will force recreation of the resource. Must match the identifier in the template_yaml.
 - `name` (String) Name of the Variable
 - `version` (String) Version Label for Template.
 

--- a/docs/resources/platform_template.md
+++ b/docs/resources/platform_template.md
@@ -1168,7 +1168,7 @@ resource "harness_platform_template" "test" {
 
 ### Required
 
-- `identifier` (String) Unique identifier of the resource. Changing this will force recreation of the resource. Must match the identifier in the template_yaml.
+- `identifier` (String) Unique identifier of the resource. Cannot be changed once the resource is created. Must match the identifier in the template_yaml.
 - `name` (String) Name of the Variable
 - `version` (String) Version Label for Template.
 

--- a/internal/service/pipeline/template/resource_template.go
+++ b/internal/service/pipeline/template/resource_template.go
@@ -2,8 +2,10 @@ package template
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/antihax/optional"
 	"github.com/harness/harness-openapi-go-client/nextgen"
@@ -23,6 +25,7 @@ func ResourceTemplate() *schema.Resource {
 		DeleteContext: resourceTemplateDelete,
 		CreateContext: resourceTemplateCreateOrUpdate,
 		Importer:      helpers.MultiLevelResourceImporter,
+		CustomizeDiff: validateIdentifierMatchesYaml,
 
 		Schema: map[string]*schema.Schema{
 			"template_yaml": {
@@ -123,6 +126,7 @@ func ResourceTemplate() *schema.Resource {
 				Description: "Unique identifier of the resource",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"name": {
 				Description: "Name of the Variable",
@@ -313,6 +317,7 @@ func resourceTemplateCreateOrUpdate(ctx context.Context, d *schema.ResourceData,
 	version := d.Get("version").(string)
 	template_yaml := d.Get("template_yaml").(string)
 	is_stable := d.Get("is_stable").(bool)
+
 	if attr, ok := d.GetOk("git_import_details"); ok {
 		config := attr.([]interface{})[0].(map[string]interface{})
 		if attr, ok := config["branch_name"]; ok {
@@ -703,6 +708,28 @@ func readTemplate(d *schema.ResourceData, template nextgen.TemplateWithInputsRes
 	if template.Template.GitDetails != nil {
 		d.Set("git_details", []interface{}{readGitDetails(template, store_type, base_branch, commit_message, connector_ref)})
 	}
+}
+
+// validateIdentifierMatchesYaml is a CustomizeDiff function that validates the identifier in the schema matches the identifier in the YAML template
+func validateIdentifierMatchesYaml(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	template_yaml := d.Get("template_yaml").(string)
+	if template_yaml == "" {
+		return nil
+	}
+
+	schemaIdentifier := d.Get("identifier").(string)
+	// Extract identifier from YAML using regex
+	identifierRegex := regexp.MustCompile(`identifier:\s*["']?([^"'\s]+)["']?`)
+	matches := identifierRegex.FindStringSubmatch(template_yaml)
+	if len(matches) > 1 {
+		yamlIdentifier := matches[1]
+		if yamlIdentifier != schemaIdentifier {
+			return fmt.Errorf("identifier in schema (%s) does not match identifier in template YAML (%s)", 
+				schemaIdentifier, yamlIdentifier)
+		}
+	}
+
+	return nil
 }
 
 func readGitDetails(template nextgen.TemplateWithInputsResponse, store_type optional.String, base_branch optional.String, commit_message optional.String, connector_ref optional.String) map[string]interface{} {

--- a/internal/service/pipeline/template/resource_template.go
+++ b/internal/service/pipeline/template/resource_template.go
@@ -126,7 +126,6 @@ func ResourceTemplate() *schema.Resource {
 				Description: "Unique identifier of the resource",
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 			},
 			"name": {
 				Description: "Name of the Variable",
@@ -711,7 +710,13 @@ func readTemplate(d *schema.ResourceData, template nextgen.TemplateWithInputsRes
 }
 
 // validateIdentifierMatchesYaml is a CustomizeDiff function that validates the identifier in the schema matches the identifier in the YAML template
+// and prevents changes to the identifier once the resource is created
 func validateIdentifierMatchesYaml(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// Prevent changes to identifier after creation
+	if d.Id() != "" && d.HasChange("identifier") {
+		return fmt.Errorf("the identifier cannot be changed once the template is created; you must create a new resource")
+	}
+
 	template_yaml := d.Get("template_yaml").(string)
 	if template_yaml == "" {
 		return nil


### PR DESCRIPTION
Title: [Template Resource] Fix identifier field to prevent changes and validate YAML consistency

Summary: This PR fixes an issue with the harness_platform_template resource where changing the identifier field would cause a perpetual diff state. The changes include:

Implemented a CustomizeDiff function that prevents changes to the identifier field after resource creation, making it immutable
Added validation during the plan phase that ensures the identifier in the schema matches the identifier in the template YAML
Updated documentation to clearly indicate that the identifier cannot be changed once the resource is created and must match the YAML template
These changes ensure consistent behavior by preventing identifier changes altogether, which better aligns with the Harness platform's behavior where identifiers are not editable. The validation during plan phase provides early feedback when identifiers don't match, improving the user experience.

**Related Issues:**
[PIPE-28924](https://harness.atlassian.net/browse/PIPE-28924)


**Screenshots:**

<img width="1220" height="339" alt="Screenshot 2025-07-26 at 2 49 06 AM" src="https://github.com/user-attachments/assets/772c8689-e420-4d1a-9816-805e6c87c79a" />
<img width="1220" height="807" alt="Screenshot 2025-07-26 at 2 49 29 AM" src="https://github.com/user-attachments/assets/3fdf36c8-48d3-4d28-bce4-4ee9575bc15c" />
<img width="1224" height="464" alt="Screenshot 2025-07-26 at 2 49 53 AM" src="https://github.com/user-attachments/assets/aa8fbcd9-5697-4139-8dd1-5d56793ff7e5" />

**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`


[PIPE-28924]: https://harness.atlassian.net/browse/PIPE-28924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ