### PR TITLE
Not setting any values of user/user_emails when isSSOLinked

### DIFF
--- a/internal/service/platform/usergroup/usergroup.go
+++ b/internal/service/platform/usergroup/usergroup.go
@@ -182,7 +182,7 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 		if emails_present || !users_present {
 			// If email is present or users is not present then use only email
 			d.Set("user_emails", ignoreOrderIfAllElementsMatch(ug.Users, flattenUserInfo(users)))
-		} else if users_present || (users != nil && !isSsoLinked && !emails_present) {
+		} else if users_present || (users != nil && !emails_present) {
 			// If users is present (Explicitly set by user for import) and email is not present (using old api) then use users
 			d.Set("users", flattenUserIds(users))
 		}

--- a/internal/service/platform/usergroup/usergroup.go
+++ b/internal/service/platform/usergroup/usergroup.go
@@ -178,14 +178,14 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, emails_present := d.GetOk("user_emails")
 	_, users_present := d.GetOk("users")
-	if emails_present || !users_present {
-		// If email is present or users is not present then use only email
-		d.Set("user_emails", ignoreOrderIfAllElementsMatch(ug.Users, flattenUserInfo(users)))
-	} else if users_present || (users != nil && !isSsoLinked && !emails_present) {
-		// If users is present (Explicitly set by user for import) and email is not present (using old api) then use users
-		d.Set("users", flattenUserIds(users))
-	} else if isSsoLinked {
-		d.Set("users", []string{})
+	if !isSsoLinked {
+		if emails_present || !users_present {
+			// If email is present or users is not present then use only email
+			d.Set("user_emails", ignoreOrderIfAllElementsMatch(ug.Users, flattenUserInfo(users)))
+		} else if users_present || (users != nil && !isSsoLinked && !emails_present) {
+			// If users is present (Explicitly set by user for import) and email is not present (using old api) then use users
+			d.Set("users", flattenUserIds(users))
+		}
 	}
 	readUserGroupV2(d, resp.Data, ug.Users, false)
 


### PR DESCRIPTION
**Title:** [Component/Feature] Short Description of the Change
Not setting any values of user/user_emails when isSSOLinked

**Summary:**
Provide a brief overview of what the PR does and why it is needed.
Not setting any values of user/user_emails when isSSOLinked

**Details:**
Explain the changes in detail, including any relevant context or background information.
Fix for the issue: https://github.com/harness/terraform-provider-harness/issues/1261#issuecomment-3069231132

**Related Issues:**
Reference any related issues or tickets 
Reference: https://github.com/harness/terraform-provider-harness/issues/1261

**Testing Instructions:**

1. Validated that in case of isSSOLinked, we're not populating users/user_emails fields. Even if the resource file has field as empty, on doing terraform plan, it would show No Changes
2. Imported with v < 0.37.6 the upgraded version with the PR changes and then ran terraform plan command -> No Changes are shown

<img width="1321" height="743" alt="Screenshot 2025-07-30 at 1 15 17 PM" src="https://github.com/user-attachments/assets/5c7db236-4c5a-49b3-80be-65941290248f" />


**Screenshots:**
Include before and after screenshots to visually demonstrate the changes.
**Checklist:**
- [x] Code changes are well-documented.
- [x] Tests have been added/updated.
- [x] Changes have been tested locally.
- [ ] Documentation has been updated.

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- gitleaks: `trigger gitleaks`
