### PR TITLE
fix: [IAC-8053]: Prevent dual git selector on workspace branch→SHA migration

### DIFF
--- a/internal/service/platform/workspace/resource_workspace.go
+++ b/internal/service/platform/workspace/resource_workspace.go
@@ -588,16 +588,16 @@ func buildUpdateWorkspace(d *schema.ResourceData) (nextgen.IacmUpdateWorkspaceRe
 		ws.Description = desc.(string)
 	}
 
-	if desc, ok := d.GetOk("repository_branch"); ok {
-		ws.RepositoryBranch = desc.(string)
+	if configHas(d, "repository_branch") {
+		ws.RepositoryBranch = d.Get("repository_branch").(string)
 	}
 
-	if desc, ok := d.GetOk("repository_commit"); ok {
-		ws.RepositoryCommit = desc.(string)
+	if configHas(d, "repository_commit") {
+		ws.RepositoryCommit = d.Get("repository_commit").(string)
 	}
 
-	if desc, ok := d.GetOk("repository_sha"); ok {
-		ws.RepositorySha = desc.(string)
+	if configHas(d, "repository_sha") {
+		ws.RepositorySha = d.Get("repository_sha").(string)
 	}
 
 	if desc, ok := d.GetOk("repository_path"); ok {
@@ -691,16 +691,16 @@ func buildCreateWorkspace(d *schema.ResourceData) (nextgen.IacmCreateWorkspaceRe
 		ws.Description = desc.(string)
 	}
 
-	if desc, ok := d.GetOk("repository_branch"); ok {
-		ws.RepositoryBranch = desc.(string)
+	if configHas(d, "repository_branch") {
+		ws.RepositoryBranch = d.Get("repository_branch").(string)
 	}
 
-	if desc, ok := d.GetOk("repository_commit"); ok {
-		ws.RepositoryCommit = desc.(string)
+	if configHas(d, "repository_commit") {
+		ws.RepositoryCommit = d.Get("repository_commit").(string)
 	}
 
-	if desc, ok := d.GetOk("repository_sha"); ok {
-		ws.RepositorySha = desc.(string)
+	if configHas(d, "repository_sha") {
+		ws.RepositorySha = d.Get("repository_sha").(string)
 	}
 
 	if desc, ok := d.GetOk("repository_path"); ok {


### PR DESCRIPTION
**Issue**
When switching a harness_platform_workspace from repository_branch to repository_sha (or any selector-to-selector change), the provider was sending both values to the API, causing a 400: "exactly one of 'repository_branch' and 'repository_commit' and 'repository_sha' must be specified".

**Root cause**
The three selector fields are marked Optional+Computed so that template-inherited values are preserved in state. However, buildUpdateWorkspace and buildCreateWorkspace used d.GetOk() which returns true for any non-empty value in state — including values inherited from a prior config or import that the user has since removed from their configuration.

**Fix**
Replace d.GetOk with configHas (which inspects GetRawConfig) for the three selector fields. This ensures only selectors explicitly present in the user's .tf config are sent to the API. Fields using json:"...,omitempty" in the SDK struct are omitted from the request entirely when left as zero-value, matching the UI behavior.

**Tested on QA** (account 25NKDX79QPC-YTyninmxRQ):
- Import branch-based workspace + apply with SHA only (the reported bug)
- Create with branch, update name (no selector change)
- In-place switch: branch→sha, sha→commit, commit→branch
- Idempotency: re-plan after apply shows no changes All passed. go vet and gofmt clean.
