### PR TITLE
docs: clarify FME flag definition 403 when environment requires approvals

### DIFF
--- a/.changelog/1404.txt
+++ b/.changelog/1404.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docs: Clarify that harness_fme_feature_flag_definition writes Split definitions directly and fails with HTTP 403 when the environment requires approvals; the full-stack example does not apply definitions to staging_with_approvals
+```

--- a/.changelog/1404.txt
+++ b/.changelog/1404.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-docs: Clarify that harness_fme_feature_flag_definition writes Split definitions directly and fails with HTTP 403 when the environment requires approvals; the full-stack example does not apply definitions to staging_with_approvals
+docs: Clarify that harness_fme_feature_flag_definition writes Split definitions directly and fails with HTTP 403 when the environment requires approvals; gated targeting needs a second identity (change-request API, UI, or pipelines), not this resource
 ```

--- a/docs/resources/fme_feature_flag_definition.md
+++ b/docs/resources/fme_feature_flag_definition.md
@@ -3,12 +3,12 @@
 page_title: "harness_fme_feature_flag_definition Resource - terraform-provider-harness"
 subcategory: "Next Gen"
 description: |-
-  Create, update, and remove a Harness FME (Split) feature flag definition in an environment. definition is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: org_id/project_id/environment_id/flag_name.
+  Create, update, and remove a Harness FME (Split) feature flag definition in an environment. definition is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. For gated environments, submit a change request with one identity and approve with another (the same user or SAT cannot approve its own request). This provider has no change-request resource; use the Split change-request API, the FME UI, or pipeline FME steps. approval_skippable_by on the environment is a group/user skip list, not a Terraform SAT bypass. Import id format: org_id/project_id/environment_id/flag_name.
 ---
 
 # harness_fme_feature_flag_definition (Resource)
 
-Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: `org_id/project_id/environment_id/flag_name`.
+Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. For gated environments, submit a change request with one identity and approve with another (the same user or SAT cannot approve its own request). This provider has no change-request resource; use the Split change-request API, the FME UI, or pipeline FME steps. `approval_skippable_by` on the environment is a group/user skip list, not a Terraform SAT bypass. Import id format: `org_id/project_id/environment_id/flag_name`.
 
 
 

--- a/docs/resources/fme_feature_flag_definition.md
+++ b/docs/resources/fme_feature_flag_definition.md
@@ -3,12 +3,12 @@
 page_title: "harness_fme_feature_flag_definition Resource - terraform-provider-harness"
 subcategory: "Next Gen"
 description: |-
-  Create, update, and remove a Harness FME (Split) feature flag definition in an environment. definition is JSON matching Split's definition payload (see Split API). Import id format: org_id/project_id/environment_id/flag_name.
+  Create, update, and remove a Harness FME (Split) feature flag definition in an environment. definition is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: org_id/project_id/environment_id/flag_name.
 ---
 
 # harness_fme_feature_flag_definition (Resource)
 
-Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Import id format: `org_id/project_id/environment_id/flag_name`.
+Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: `org_id/project_id/environment_id/flag_name`.
 
 
 
@@ -17,7 +17,7 @@ Create, update, and remove a Harness FME (Split) feature flag definition in an e
 
 ### Required
 
-- `definition` (String) JSON object for the split definition (treatments, defaultTreatment, defaultRule, trafficAllocation, rules, etc.).
+- `definition` (String) JSON object for the split definition (treatments, defaultTreatment, defaultRule, trafficAllocation, rules, etc.). Written directly to the Split definition API. Fails with HTTP 403 when the environment requires approvals.
 - `environment_id` (String) Split environment ID.
 - `flag_name` (String) Feature flag (split) name.
 - `org_id` (String) Harness organization identifier.

--- a/examples/resources/harness_fme_full_stack/main.tf
+++ b/examples/resources/harness_fme_full_stack/main.tf
@@ -9,6 +9,16 @@
 #   terraform apply -var="name_prefix=mydemo"
 #
 # Optional: set -var="skip_api_key=true" to skip harness_fme_api_key (avoids minting a real Split API key).
+#
+# Typical split of concerns (this example follows it):
+#   Terraform: org/project, FME environments, traffic types, segments, API keys,
+#   project-level flags, and definitions only on environments that do not require
+#   approvals (alpha/beta here).
+#   Gated targeting (staging_with_approvals): do not attach
+#   harness_fme_feature_flag_definition. Use the FME UI, pipeline FME steps, or the
+#   Split change-request API. A change request must be submitted and approved by
+#   two different identities; the SAT Terraform uses cannot approve its own request.
+#   approval_skippable_by is a group/user skip list, not a Terraform SAT bypass.
 
 terraform {
   required_version = ">= 1.3.0"
@@ -184,10 +194,9 @@ resource "harness_platform_usergroup" "approvers" {
 }
 
 # Demonstrates change_permissions (approvals) on an extra environment.
-# harness_fme_feature_flag_definition below only covers local.fme_environment_keys
-# (alpha/beta). Do not attach a definition to this environment: create/update
-# write the Split definition API directly and typically return HTTP 403 when
-# approvals are required. This resource does not create or approve change requests.
+# Definitions below only cover local.fme_environment_keys (alpha/beta).
+# Do not attach harness_fme_feature_flag_definition here: direct writes return 403.
+# Gated targeting needs a change request (submitter SAT != approver SAT).
 resource "harness_fme_environment" "staging_with_approvals" {
   org_id     = harness_platform_organization.this.id
   project_id = harness_platform_project.this.id

--- a/examples/resources/harness_fme_full_stack/main.tf
+++ b/examples/resources/harness_fme_full_stack/main.tf
@@ -183,6 +183,11 @@ resource "harness_platform_usergroup" "approvers" {
   project_id = harness_platform_project.this.id
 }
 
+# Demonstrates change_permissions (approvals) on an extra environment.
+# harness_fme_feature_flag_definition below only covers local.fme_environment_keys
+# (alpha/beta). Do not attach a definition to this environment: create/update
+# write the Split definition API directly and typically return HTTP 403 when
+# approvals are required. This resource does not create or approve change requests.
 resource "harness_fme_environment" "staging_with_approvals" {
   org_id     = harness_platform_organization.this.id
   project_id = harness_platform_project.this.id
@@ -261,6 +266,7 @@ resource "harness_fme_feature_flag" "toggle" {
   tags            = ["terraform-example", "fme-stack"]
 }
 
+# Definitions only for alpha/beta (no approvals). Not for staging_with_approvals.
 resource "harness_fme_feature_flag_definition" "toggle" {
   for_each       = local.fme_environment_keys
   org_id         = harness_platform_organization.this.id

--- a/internal/service/split/resource_fme_feature_flag_definition.go
+++ b/internal/service/split/resource_fme_feature_flag_definition.go
@@ -13,7 +13,7 @@ import (
 // ResourceFMEFeatureFlagDefinition manages a Split feature flag definition in one environment.
 func ResourceFMEFeatureFlagDefinition() *schema.Resource {
 	return &schema.Resource{
-		Description: "Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Import id format: `org_id/project_id/environment_id/flag_name`.",
+		Description: "Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: `org_id/project_id/environment_id/flag_name`.",
 
 		CreateContext: resourceFMEFeatureFlagDefinitionCreate,
 		ReadContext:   resourceFMEFeatureFlagDefinitionRead,
@@ -50,7 +50,7 @@ func ResourceFMEFeatureFlagDefinition() *schema.Resource {
 				ForceNew:    true,
 			},
 			"definition": {
-				Description: "JSON object for the split definition (treatments, defaultTreatment, defaultRule, trafficAllocation, rules, etc.).",
+				Description: "JSON object for the split definition (treatments, defaultTreatment, defaultRule, trafficAllocation, rules, etc.). Written directly to the Split definition API. Fails with HTTP 403 when the environment requires approvals.",
 				Type:        schema.TypeString,
 				Required:    true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {

--- a/internal/service/split/resource_fme_feature_flag_definition.go
+++ b/internal/service/split/resource_fme_feature_flag_definition.go
@@ -13,7 +13,7 @@ import (
 // ResourceFMEFeatureFlagDefinition manages a Split feature flag definition in one environment.
 func ResourceFMEFeatureFlagDefinition() *schema.Resource {
 	return &schema.Resource{
-		Description: "Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. Import id format: `org_id/project_id/environment_id/flag_name`.",
+		Description: "Create, update, and remove a Harness FME (Split) feature flag definition in an environment. `definition` is JSON matching Split's definition payload (see Split API). Create and update write the definition directly; they do not create or approve change requests. If the environment requires approvals, those calls typically fail with HTTP 403. For gated environments, submit a change request with one identity and approve with another (the same user or SAT cannot approve its own request). This provider has no change-request resource; use the Split change-request API, the FME UI, or pipeline FME steps. `approval_skippable_by` on the environment is a group/user skip list, not a Terraform SAT bypass. Import id format: `org_id/project_id/environment_id/flag_name`.",
 
 		CreateContext: resourceFMEFeatureFlagDefinitionCreate,
 		ReadContext:   resourceFMEFeatureFlagDefinitionRead,


### PR DESCRIPTION
## Summary
- Document that `harness_fme_feature_flag_definition` writes Split definitions directly and does not create or approve change requests.
- Note that create/update typically fail with HTTP 403 when the environment requires approvals.
- Comment the full-stack example: Terraform for envs/traffic types/non-gated definitions; gated targeting uses UI, pipeline FME steps, or the Split change-request API with two identities (submitter SAT cannot approve its own request). `approval_skippable_by` is not a Terraform SAT bypass.

Fixes https://github.com/harness/terraform-provider-harness/issues/1404

## Test plan
- [ ] Schema descriptions mention 403, no change-request resource, two-identity approve
- [ ] Full-stack example header matches alpha/beta vs `staging_with_approvals`
- [x] Unit tests previously: `go test ./internal/service/split/ -skip TestAcc`